### PR TITLE
Remove unnecessary output related to duplicate region checking

### DIFF
--- a/residentevil3remake/__init__.py
+++ b/residentevil3remake/__init__.py
@@ -73,8 +73,7 @@ class ResidentEvil3Remake(World):
 
         for region in regions:
             if region.name in added_regions:
-             print("Skipping duplicate region {}...".format(region.name))
-             continue
+                continue
 
             added_regions.append(region.name)
             region.locations = [


### PR DESCRIPTION
Saw this mentioned in the Discord and had a moment, so figured I'd go ahead and PR this quick fix.

The duplicate region checking that RE3R does outputs a message when it's skipping a region, but this might look like an error to users. So this PR removes the unnecessary message.