### PR TITLE
RE3R Ver2 Update

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ All of the scenarios' data lives in the `data` folder. The structure of the data
   - [Region Zones file](#region-zones-file)
 
 ### Character folder
-Data is loaded from the `jill` data folder, it contains all the scenario data and everything else involving the scenarios.
+Data is loaded from the `jill` character folder, it contains all the scenario data and everything else involving the scenarios.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -5,8 +5,8 @@ An Archipelago (AP) randomizer world for Resident Evil 3 Remake. Designed for us
 Follow the visual setup guide here: https://dontjoome.github.io/RE3R_AP_SetupGuide/
 
 ## What scenario/difficulty does this support?
-Standard/Hardcore/Nightmare/Inferno are all supported.
-Just don't play on Assisted and you'll be fine. 
+All scenarios are currently supported.
+If you play on Assisted, make sure you choose Standard in your yaml. 
 
 ## How is the scenarios data structured?
 All of the scenarios' data lives in the `data` folder. The structure of the data is:
@@ -22,7 +22,7 @@ All of the scenarios' data lives in the `data` folder. The structure of the data
   - [Region Zones file](#region-zones-file)
 
 ### Character folder
-Each character is separated into its own folder to group their scenarios together.
+Data is loaded from the `jill` data folder, it contains all the scenario data and everything else involving the scenarios.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Grab the latest client here: https://github.com/dontjoome/RE3R_AP_Client/
 Follow the visual setup guide here: https://dontjoome.github.io/RE3R_AP_SetupGuide/
 
 ## What scenario/difficulty does this support?
-All scenarios are currently supported.
+All scenarios are currently supported.<br />
 If you play on Assisted, make sure you choose Standard in your yaml. 
 
 ## How is the scenarios data structured?

--- a/README.md
+++ b/README.md
@@ -1,7 +1,10 @@
 # RE3R Archipelago World
 An Archipelago (AP) randomizer world for Resident Evil 3 Remake. Designed for use with the RE3R Archipelago client repository linked below.
 
-## How to generate and play an RE3R randomized world
+## RE3R Archipelago Client
+Grab the latest client here: https://github.com/dontjoome/RE3R_AP_Client/
+
+## How to get setup, generate and play an RE3R randomized world
 Follow the visual setup guide here: https://dontjoome.github.io/RE3R_AP_SetupGuide/
 
 ## What scenario/difficulty does this support?

--- a/residentevil3remake/Options.py
+++ b/residentevil3remake/Options.py
@@ -88,9 +88,9 @@ class AllowMissableLocations(Choice):
 
     False: (Default) Will place items so they are not permanently missable.
     This severely limits where progression can be to prevent softlocking of any kind. 
-    Will also remove progression for others if multiworld.
+    Will also remove progression from those location if for others in a multiworld.
     
-    True: Progression can be placed in locations that can be missed if story progresses too far, you've been warned (use the poptracker).
+    True: Progression can be placed in locations that can be missed if story progresses too far, you've been warned.
 
     NOTE - This option only affects *YOUR* game. Your progression can still be in someone else's if they have this option enabled."""
     display_name = "Allow Missable Locations"
@@ -106,7 +106,7 @@ class AllowProgressionInLabs(Choice):
 
     True: Progression can be placed in NEST, remind everyone it was your fault when you are holding them hostage.
 
-    NOTE - This option only affects multiworlds."""
+    NOTE - This option only affects *YOUR* game. Your progression can still be in someone else's Labs if they have this option enabled."""
     display_name = "Allow Progression in Labs"
     option_false = 0
     option_true = 1

--- a/residentevil3remake/Options.py
+++ b/residentevil3remake/Options.py
@@ -106,11 +106,39 @@ class AllowProgressionInLabs(Choice):
 
     True: Progression can be placed in NEST, remind everyone it was your fault when you are holding them hostage.
 
-    NOTE - This option only affects *YOUR* NEST. Your progression can still be in someone else's if they have this option enabled."""
+    NOTE - This option only affects multiworlds."""
     display_name = "Allow Progression in Labs"
     option_false = 0
     option_true = 1
     default = 0
+	
+class AmmoPackModifier(Choice):
+    """This option, when set, will modify the quantity of ammo in each ammo pack. This can make the game easier or much, much harder.
+    The available options are:
+
+    None: You realized that consistency in ammo pack quantities is one of the few true joys in life, and this causes you to not modify them at all.
+    Max: Each ammo pack will contain the maximum amount of ammo that the game allows. (i.e., you will never, ever run out of ammo.)
+    Double: Each ammo pack will contain twice as much ammo as it normally contains.
+    Half: Each ammo pack will contain half as much ammo as it normally contains.
+    Only Three: Each ammo pack will have an ammo count of 3.
+    Only Two: Each ammo pack will have an ammo count of 2.
+    Only One: Each ammo pack will have an ammo count of 1. (Yes, your Handgun Ammo pack will have a single bullet in it.)
+    Random By Type: Each ammo type's ammo pack will have a random quantity of ammo, and you will get that same quantity of ammo from every pack for that ammo type.
+        (For example, you receive a Shotgun Shells pack that has a random quantity of 7 ammo. All Shotgun Shells packs will have a quantity of 7.)
+    Random Always: Each ammo pack will have a random quantity of ammo, and that quantity will be randomized every time.
+        (For example, you receive a Shotgun Shells pack that has a random quantity of 7 ammo. Your next Shotgun Shells pack has a quantity of 4, next has 2, etc.)
+
+    NOTE: The options for "Only Three", "Only Two", "Only One", "Random By Type", and "Random Always" are not guaranteed to be reasonably beatable."""
+    display_name = "Ammo Pack Modifier"
+    option_none = 0
+    option_max = 1
+    option_double = 2
+    option_half = 3
+    option_only_three = 4
+    option_only_two = 5
+    option_only_one = 6
+    option_random_by_type = 7
+    option_random_always = 8
 	
 class OopsAllGrenades(Choice):
     """Enabling this swaps all weapons, weapon ammo, subweapons and explosive/gunpowder to Grenades. 
@@ -189,50 +217,6 @@ class DamageTrapsCanKill(Choice):
     option_false = 0
     option_true = 1
     default = 0
-    
-# class AddParasiteTraps(Choice):
-    # """Enabling this adds traps to your game that, when received, gives you parasites. e.g., when you get grabbed by deimos. 
-    # These traps cannot kill you, but they will continuously damage you over time, similar to the Poison status in RE2R.
-    # """
-    # display_name = "Add Parasite Traps"
-    # option_false = 0
-    # option_true = 1
-    # default = 0
-
-# class ParasiteTrapCount(NamedRange):
-    # """While the "AddParasiteTraps" option is enabled, this option specifies how many of this trap should be placed.
-    # """
-    # default = 10
-    # range_start = 0
-    # range_end = 30 
-    # display_name = "Parasite Trap Count"
-    # special_range_names = {
-    #     "disabled": 0,
-    #     "half": 15,
-    #     "all": 30,
-    # }
-    
-# class AddPukeTraps(Choice):
-    # """Enabling this adds traps to your game that, when received, will cause you to vomit. e.g., when you heal yourself from parasites. 
-    # These traps are more of a nuisance than anything, but can be trolly if you're in the middle of combat.
-    # """
-    # display_name = "Add Puke Traps"
-    # option_false = 0
-    # option_true = 1
-    # default = 0
-    
-# class PukeTrapCount(NamedRange):
-    # """While the "AddPukeTraps" option is enabled, this option specifies how many of this trap should be placed.
-    # """
-    # default = 10
-    # range_start = 0
-    # range_end = 30 
-    # display_name = "Puke Trap Count"
-    # special_range_names = {
-    #     "disabled": 0,
-    #     "half": 15,
-    #     "all": 30,
-    # }
 
 # making this mixin so we can keep actual game options separate from AP core options that we want enabled
 # not sure why this isn't a mixin in core atm, anyways
@@ -252,6 +236,7 @@ class RE3ROptions(StartInventoryFromPoolMixin, DeathLinkMixin, PerGameCommonOpti
     extra_sewer_items: ExtraSewerItems
     allow_missable_locations: AllowMissableLocations
     allow_progression_in_labs: AllowProgressionInLabs
+    ammo_pack_modifier: AmmoPackModifier
     oops_all_grenades: OopsAllGrenades
     oops_all_handguns: OopsAllHandguns
     no_first_aid_spray: NoFirstAidSpray
@@ -261,8 +246,4 @@ class RE3ROptions(StartInventoryFromPoolMixin, DeathLinkMixin, PerGameCommonOpti
     add_damage_traps: AddDamageTraps
     damage_trap_count: DamageTrapCount
     damage_traps_can_kill: DamageTrapsCanKill
-    # add_parasite_traps: AddParasiteTraps
-    # parasite_trap_count: ParasiteTrapCount
-    # add_puke_traps: AddPukeTraps
-    # puke_trap_count: PukeTrapCount
 

--- a/residentevil3remake/Options.py
+++ b/residentevil3remake/Options.py
@@ -20,8 +20,10 @@ class Scenario(Choice):
 class Difficulty(Choice):
     """Standard: Most people should play on this.
     Hardcore: Slightly tougher, but not by much. 
-    Nightmare: It actually rains zombies, Kappa
-    Inferno: Hope your name isn't Gohan, because you need to dodge... a lot"""
+    Nightmare: It actually rains zombies, Kappa.
+    Inferno: Hope your name isn't Gohan, because you need to dodge a lot.
+    
+    NOTE: You can play Assisted difficulty in-game, but make sure you choose Standard for this setting."""
     display_name = "Difficulty to Play On"
     option_standard = 0
     option_hardcore = 1
@@ -64,15 +66,15 @@ class EarlyFireHose(Choice):
     """Receiving Fire Hose late can lead to some intense BK.
     This option will place it early to lower the odds of BK.
 
-    False: Normal, will place it anywhere in the world and you may be waiting a bit to progress.
-    True: Will place it in Sphere 1 of the world, and should prevent lengthy BK."""
+    False: Will place it anywhere in the seed, which if multiworld can lead to lengthy BK.
+    True: Will place it in Sphere 1 of the seed, and should prevent BK."""
     display_name = "Early Fire Hose"
     option_false = 0
     option_true = 1
     default = 0
 
 class ExtraSewerItems(Choice):
-    """Not getting Battery Pack or Kendo's Gate Key early can lead to the same situation.
+    """Receiving Battery Pack or Kendo's Gate Key late can lead to the same situation.
     This option adds an extra set of these items so the odds of BK are lower.
 
     False: Normal, only 1 of each are in the item pool.
@@ -88,7 +90,7 @@ class AllowMissableLocations(Choice):
 
     False: (Default) Will place items so they are not permanently missable.
     This severely limits where progression can be to prevent softlocking of any kind. 
-    Will also remove progression from those location if for others in a multiworld.
+    Will also remove progression from those locations if for others in a multiworld.
     
     True: Progression can be placed in locations that can be missed if story progresses too far, you've been warned.
 
@@ -98,7 +100,7 @@ class AllowMissableLocations(Choice):
     option_true = 1
     default = 0
     
-class AllowProgressionInLabs(Choice):
+class AllowProgressionInNEST(Choice):
     """While next to impossible to skip anything in NEST, it would certainly feel bad if someones Morph Ball ended up there.
     This option will completely remove progression from being at your end game, including the ten locations in Nemesis Final Fight. 
 
@@ -106,8 +108,8 @@ class AllowProgressionInLabs(Choice):
 
     True: Progression can be placed in NEST, remind everyone it was your fault when you are holding them hostage.
 
-    NOTE - This option only affects *YOUR* game. Your progression can still be in someone else's Labs if they have this option enabled."""
-    display_name = "Allow Progression in Labs"
+    NOTE - This option only affects *YOUR* game. Your progression can still be in someone else's NEST if they have this option enabled."""
+    display_name = "Allow Progression in NEST"
     option_false = 0
     option_true = 1
     default = 0
@@ -142,15 +144,15 @@ class AmmoPackModifier(Choice):
 	
 class OopsAllGrenades(Choice):
     """Enabling this swaps all weapons, weapon ammo, subweapons and explosive/gunpowder to Grenades. 
-    (Except your starting weapon, the shotgun, and maybe one grenade launcher if it decides to spawn in the labs.)"""
+    (Except your starting weapon)"""
     display_name = "Oops! All Grenades"
     option_false = 0
     option_true = 1
     default = 0
     
 class OopsAllHandguns(Choice):
-    """Enabling this swaps all weapons, weapon ammo, subweapons and explosive/gunpowder to Handgun Ammo. 
-    (Except your starting weapon, the shotgun, and maybe one grenade launcher if it decides to spawn in the labs)"""
+    """Enabling this swaps all weapons, weapon ammo, subweapons and explosive/gunpowder to Handgun Ammo.
+    """
     display_name = "Oops! All Handguns"
     option_false = 0
     option_true = 1
@@ -235,7 +237,7 @@ class RE3ROptions(StartInventoryFromPoolMixin, DeathLinkMixin, PerGameCommonOpti
     early_fire_hose: EarlyFireHose
     extra_sewer_items: ExtraSewerItems
     allow_missable_locations: AllowMissableLocations
-    allow_progression_in_labs: AllowProgressionInLabs
+    allow_progression_in_nest: AllowProgressionInNEST
     ammo_pack_modifier: AmmoPackModifier
     oops_all_grenades: OopsAllGrenades
     oops_all_handguns: OopsAllHandguns

--- a/residentevil3remake/__init__.py
+++ b/residentevil3remake/__init__.py
@@ -73,7 +73,7 @@ class ResidentEvil3Remake(World):
 
         for region in regions:
             if region.name in added_regions:
-                continue
+             continue
 
             added_regions.append(region.name)
             region.locations = [
@@ -107,7 +107,7 @@ class ResidentEvil3Remake(World):
                     if not current_item_rule:
                         current_item_rule = lambda x: True
 
-                    location.item_rule = lambda item, location_data=location_data: RE3RLocation.is_item_allowed(item, location_data, current_item_rule)
+                    location.item_rule = lambda item: RE3RLocation.is_item_allowed(item, location_data, current_item_rule)
 
                 # now, set rules for the location access
                 if "condition" in location_data and "items" in location_data["condition"]:
@@ -245,7 +245,14 @@ class ResidentEvil3Remake(World):
                 trap_to_place = traps.pop()
                 pool.remove(spot)
                 pool.append(trap_to_place)
-				
+	
+        early_items = {}  
+        early_items["ID Card"] = len([i for i in pool if i.name == "ID Card"])     
+
+        for item_name, item_qty in early_items.items():
+            if item_qty > 0:
+                self.multiworld.early_items[self.player][item_name] = item_qty
+			
 	# Add option for early/extras for Downtown items or Sewer Stuff, if configured
         # doing this before "oops all X" to make use of extra Handgun Ammo spots, too
         if self._format_option_text(self.options.early_fire_hose) == 'True':
@@ -254,7 +261,7 @@ class ResidentEvil3Remake(World):
 
             for item_name, item_qty in early_items.items():
                 if item_qty > 0:
-                    self.multiworld.early_items[self.player][item_name] = item_qty
+                    self.multiworld.early_items[self.player][item_name] = item_qty  
 
         if self._format_option_text(self.options.extra_sewer_items) == 'True':
             replaceables = [item for item in pool if item.name == 'Green Herb' or item.name == 'Handgun Ammo']

--- a/residentevil3remake/__init__.py
+++ b/residentevil3remake/__init__.py
@@ -37,7 +37,7 @@ class ResidentEvil3Remake(World):
 
     data_version = 2
     required_client_version = (0, 5, 0)
-    apworld_release_version = "0.1.6" # defined to show in spoiler log
+    apworld_release_version = "0.2.0" # defined to show in spoiler log
 
     item_id_to_name = { item['id']: item['name'] for item in Data.item_table }
     item_name_to_id = { item['name']: item['id'] for item in Data.item_table }
@@ -99,7 +99,6 @@ class ResidentEvil3Remake(World):
                     location.item_rule = lambda item: not item.advancement
                 elif self._format_option_text(self.options.allow_progression_in_labs) == 'False' and region_data['zone_id'] == 6:
                     location.item_rule = lambda item: not item.advancement
-		# END
 
                 if 'allow_item' in location_data and location_data['allow_item']:
                     current_item_rule = location.item_rule or None
@@ -165,7 +164,7 @@ class ResidentEvil3Remake(World):
             # if the hip pouches option exceeds the number of hip pouches in the pool, reduce it to the number in the pool
             if starting_hip_pouches > len(hip_pouches):
                 starting_hip_pouches = len(hip_pouches)
-                self.options.starting_hip_pouches = len(hip_pouches)
+                self.options.starting_hip_pouches.value = len(hip_pouches)
 
             for x in range(starting_hip_pouches):
                 self.multiworld.push_precollected(hip_pouches[x]) # starting inv
@@ -208,14 +207,6 @@ class ResidentEvil3Remake(World):
         if self._format_option_text(self.options.add_damage_traps) == 'True':
             for x in range(int(self.options.damage_trap_count)):
                 traps.append(self.create_item("Damage Trap"))
-                
-        # if self._format_option_text(self.options.add_parasite_traps) == 'True':
-            # for x in range(int(self.options.parasite_trap_count)):
-                # traps.append(self.create_item("Parasite Trap"))
-                
-        # if self._format_option_text(self.options.add_puke_traps) == 'True':
-            # for x in range(int(self.options.puke_trap_count)):
-                # traps.append(self.create_item("Puke Trap"))
                 
         if len(traps) > 0:
             # use these spots for replacement first, since they're entirely non-essential
@@ -322,7 +313,8 @@ class ResidentEvil3Remake(World):
         else: # it's Filler
             classification = ItemClassification.filler
 
-        return Item(item['name'], classification, item['id'], player=self.player)
+        new_item = Item(item['name'], classification, item['id'], player=self.player)
+        return new_item
 
     def get_filler_item_name(self) -> str:
         return "Flash Grenade"
@@ -333,6 +325,7 @@ class ResidentEvil3Remake(World):
             "scenario": self._get_scenario(),
             "difficulty": self._get_difficulty(),
             "unlocked_typewriters": self._format_option_text(self.options.unlocked_typewriters).split(", "),
+            "ammo_pack_modifier": self._format_option_text(self.options.ammo_pack_modifier),
             "damage_traps_can_kill": self._format_option_text(self.options.damage_traps_can_kill) == 'True',
             "death_link": self._format_option_text(self.options.death_link) == 'Yes' # why is this yes? lol
         }
@@ -344,20 +337,38 @@ class ResidentEvil3Remake(World):
         # print (self._output_items_and_locations_as_text()) - For printing item locations out during generation of a seed.
 
     def _has_items(self, state: CollectionState, item_names: list) -> bool:
-        # if it requires all unique items, just do a state has all
-        if len(set(item_names)) == len(item_names):
-            return state.has_all(item_names, self.player)
-        # else, it requires some duplicates, so let's group them up and do some has w/ counts
-        else:
-            item_counts = {
-                item_name: len([i for i in item_names if i == item_name]) for item_name in item_names # e.g., { Spare Key: 2 }
-            }
-
-            for item_name, count in item_counts.items():
-                if not state.has(item_name, self.player, count):
-                    return False
-                
+        # if there are no item requirements, this location is open, they "have the items needed"
+        if len(item_names) == 0:
             return True
+
+        # if the requirements are a single set of items, make it a list of a single set of items to support looping for multiple sets (below)
+        if len(item_names) > 0 and type(item_names[0]) is not list:
+            item_names = [item_names]
+
+        for set_of_requirements in item_names:
+            # if it requires all unique items, just do a state has all
+            if len(set(set_of_requirements)) == len(set_of_requirements):
+                if state.has_all(set_of_requirements, self.player):
+                    return True
+            # else, it requires some duplicates, so let's group them up and do some has w/ counts
+            else:
+                item_counts = {
+                    item_name: len([i for i in set_of_requirements if i == item_name]) for item_name in set_of_requirements # e.g., { Spare Key: 2 }
+                }
+                missing_an_item = False
+
+                for item_name, count in item_counts.items():
+                    if not state.has(item_name, self.player, count):
+                        missing_an_item = True
+
+                if missing_an_item:
+                    continue # didn't meet these requirements, so skip to the next set, if any
+                
+                # if we made it here, state has all the items and the quantities needed, return True
+                return True
+
+        # if we made it here, state didn't have enough to return True, so return False
+        return False
 
     def _format_option_text(self, option) -> str:
         return re.sub(r'\w+\(', '', str(option)).rstrip(')')

--- a/residentevil3remake/__init__.py
+++ b/residentevil3remake/__init__.py
@@ -97,7 +97,7 @@ class ResidentEvil3Remake(World):
                 # These options severely limits where items can be..
                 elif self._format_option_text(self.options.allow_missable_locations) == 'False' and region_data['zone_id'] != 6:
                     location.item_rule = lambda item: not item.advancement
-                elif self._format_option_text(self.options.allow_progression_in_labs) == 'False' and region_data['zone_id'] == 6:
+                elif self._format_option_text(self.options.allow_progression_in_nest) == 'False' and region_data['zone_id'] == 6:
                     location.item_rule = lambda item: not item.advancement
 
                 if 'allow_item' in location_data and location_data['allow_item']:

--- a/residentevil3remake/data/jill/a/locations.json
+++ b/residentevil3remake/data/jill/a/locations.json
@@ -2559,59 +2559,14 @@
     {
         "name": "Cart 1",
         "region": "Operating Room",
-        "original_item": "Flash Grenade",
+        "original_item": "Green Herb",
         "condition": {},
-        "item_object": "WP6300",
-        "parent_object": "st04_0108_Wp6300_01",
+        "item_object": "sm70_001",
+        "parent_object": "st04_0108_sm70_001_00",
         "folder_path": "RopewayContents/World/Location_Hospital/LocationLevel_Hospital/Item/common/st04_0108"
     },
     {
         "name": "Cart 2",
-        "region": "Operating Room",
-        "original_item": "Hand Grenade",
-        "condition": {},
-        "item_object": "WP6200",
-        "parent_object": "st04_0108_wp6100_01",
-        "folder_path": "RopewayContents/World/Location_Hospital/LocationLevel_Hospital/Item/common/st04_0108"
-    },
-    {
-        "name": "Cart 3",
-        "region": "Operating Room",
-        "original_item": "Flash Grenade",
-        "condition": {},
-        "item_object": "WP6300",
-        "parent_object": "st04_0108_Wp6300_00",
-        "folder_path": "RopewayContents/World/Location_Hospital/LocationLevel_Hospital/Item/common/st04_0108"
-    },
-    {
-        "name": "Cart 4",
-        "region": "Operating Room",
-        "original_item": "Hand Grenade",
-        "condition": {},
-        "item_object": "WP6200",
-        "parent_object": "st04_0108_wp6100_00",
-        "folder_path": "RopewayContents/World/Location_Hospital/LocationLevel_Hospital/Item/common/st04_0108"
-    },
-    {
-        "name": "Cart 5",
-        "region": "Operating Room",
-        "original_item": "Assault Rifle Ammo",
-        "condition": {},
-        "item_object": "sm70_102",
-        "parent_object": "st04_0108_sm70_102_00",
-        "folder_path": "RopewayContents/World/Location_Hospital/LocationLevel_Hospital/Item/common/ES_common/Item/st04_0108"
-    },
-    {
-        "name": "Cart 6",
-        "region": "Operating Room",
-        "original_item": "Assault Rifle Ammo",
-        "condition": {},
-        "item_object": "sm70_102",
-        "parent_object": "st04_0108_sm70_102_01",
-        "folder_path": "RopewayContents/World/Location_Hospital/LocationLevel_Hospital/Item/common/ES_common/Item/st04_0108"
-    },
-    {
-        "name": "Cart 7",
         "region": "Operating Room",
         "original_item": "Handgun Ammo",
         "condition": {},
@@ -2620,12 +2575,57 @@
         "folder_path": "RopewayContents/World/Location_Hospital/LocationLevel_Hospital/Item/common/st04_0108"
     },
     {
+        "name": "Cart 3",
+        "region": "Operating Room",
+        "original_item": "Assault Rifle Ammo",
+        "condition": {},
+        "item_object": "sm70_102",
+        "parent_object": "st04_0108_sm70_102_01",
+        "folder_path": "RopewayContents/World/Location_Hospital/LocationLevel_Hospital/Item/common/ES_common/Item/st04_0108"
+    },
+    {
+        "name": "Cart 4",
+        "region": "Operating Room",
+        "original_item": "Assault Rifle Ammo",
+        "condition": {},
+        "item_object": "sm70_102",
+        "parent_object": "st04_0108_sm70_102_00",
+        "folder_path": "RopewayContents/World/Location_Hospital/LocationLevel_Hospital/Item/common/ES_common/Item/st04_0108"
+    },
+    {
+        "name": "Cart 5",
+        "region": "Operating Room",
+        "original_item": "Hand Grenade",
+        "condition": {},
+        "item_object": "WP6200",
+        "parent_object": "st04_0108_wp6100_00",
+        "folder_path": "RopewayContents/World/Location_Hospital/LocationLevel_Hospital/Item/common/st04_0108"
+    },
+    {
+        "name": "Cart 6",
+        "region": "Operating Room",
+        "original_item": "Flash Grenade",
+        "condition": {},
+        "item_object": "WP6300",
+        "parent_object": "st04_0108_Wp6300_00",
+        "folder_path": "RopewayContents/World/Location_Hospital/LocationLevel_Hospital/Item/common/st04_0108"
+    },
+    {
+        "name": "Cart 7",
+        "region": "Operating Room",
+        "original_item": "Hand Grenade",
+        "condition": {},
+        "item_object": "WP6200",
+        "parent_object": "st04_0108_wp6100_01",
+        "folder_path": "RopewayContents/World/Location_Hospital/LocationLevel_Hospital/Item/common/st04_0108"
+    },
+    {
         "name": "Cart 8",
         "region": "Operating Room",
-        "original_item": "Green Herb",
+        "original_item": "Flash Grenade",
         "condition": {},
-        "item_object": "sm70_001",
-        "parent_object": "st04_0108_sm70_001_00",
+        "item_object": "WP6300",
+        "parent_object": "st04_0108_Wp6300_01",
         "folder_path": "RopewayContents/World/Location_Hospital/LocationLevel_Hospital/Item/common/st04_0108"
     },
     {

--- a/residentevil3remake/data/jill/a/locations.json
+++ b/residentevil3remake/data/jill/a/locations.json
@@ -76,6 +76,25 @@
         ]
     },
     {
+        "name": "Breakable Box",
+        "region": "Subway Station",
+        "original_item": "Red Herb",
+        "condition": {},
+        "item_object": "sm70_002",
+        "parent_object": "ItemPositions",
+        "folder_path": "RopewayContents/World/Location_DownTown/Environments/st03_0201_0/gimmick",
+        "allow_item": [
+            "Fire Hose",
+            "Battery Pack",
+            "Kendo Gate Key",
+            "Locker Room Key",
+            "Tape Player",
+            "Fuse 1",
+            "Fuse 2",
+            "Fuse 3"
+        ]
+    },
+    {
         "name": "Attache Case",
         "region": "Subway Station",
         "original_item": "Shotgun Shells",
@@ -152,6 +171,15 @@
         "folder_path": "RopewayContents/World/Location_DownTown/LocationLevel_DownTown/LocationFsm_DownTown/S03_1000/ES_S03_1000/Item/ES_S03_1000/I_100_Subway_Area"
     },
     {
+        "name": "Breakable Box",
+        "region": "Main Avenue",
+        "original_item": "Gunpowder",
+        "condition": {},
+        "item_object": "sm70_205",
+        "parent_object": "ItemPositions",
+        "folder_path": "RopewayContents/World/Location_DownTown/Environments/st03_0208_0/gimmick"  
+    },
+    {
         "name": "Counter",
         "region": "Toy Shop",
         "original_item": "Fancy Box - Green Jewel",
@@ -196,6 +224,15 @@
         "parent_object": "sm70_205",
         "folder_path": "RopewayContents/World/Location_DownTown/LocationLevel_DownTown/LocationFsm_DownTown/S03_1000/ES_S03_1000/Item/ES_S03_1000/I_300_DounutShop_Area"
     },
+    {
+        "name": "Breakable Box",
+        "region": "Building Rooftop",
+        "original_item": "Green Herb",
+        "condition": {},
+        "item_object": "sm70_001",
+        "parent_object": "ItemPositions",
+        "folder_path": "RopewayContents/World/Location_DownTown/Environments/st03_0213_0/gimmick"		
+    }, 
     {
         "name": "Downed Zombie",
         "region": "Building Rooftop",
@@ -309,7 +346,25 @@
         "condition": {},
         "item_object": "sm70_100",
         "parent_object": "sm70_100_hgsehll",
-        "folder_path": "RopewayContents/World/Location_DownTown/LocationLevel_DownTown/LocationFsm_DownTown/S03_1000/ES_S03_1000/Item/ES_S03_1000/I_500_Owner_House"
+        "folder_path": "RopewayContents/World/Location_DownTown/LocationLevel_DownTown/LocationFsm_DownTown/S03_1000/ES_S03_1000/Item/ES_S03_1000/I_500_Owner_House"  
+    },
+    {
+        "name": "North Side Breakable Box",
+        "region": "Business Street",
+        "original_item": "Green Herb",
+        "condition": {},
+        "item_object": "sm70_001",
+        "parent_object": "ItemPositions",
+        "folder_path": "RopewayContents/World/Location_DownTown/Environments/st03_0219_0/gimmick"		  
+    },
+    {
+        "name": "South Side Breakable Box",
+        "region": "Business Street",
+        "original_item": "Gunpowder",
+        "condition": {},
+        "item_object": "sm70_205",
+        "parent_object": "ItemPositions",
+        "folder_path": "RopewayContents/World/Location_DownTown/Environments/st03_0219_0/gimmick"		  
     },
     {
         "name": "Table Next to Donut Shop",
@@ -386,6 +441,18 @@
         "item_object": "sm70_205",
         "parent_object": "sm70_205_gunp_In_Locker",
         "folder_path": "RopewayContents/World/Location_DownTown/LocationLevel_DownTown/LocationFsm_DownTown/S03_1000/ES_S03_1000/Item/ES_S03_1000/I_600_ControlStation_Area/I_ControlRoom"
+    },
+    {
+        "name": "In Case of Emergency",
+        "region": "Subway Office",
+        "original_item": "M3",
+        "condition": {
+            "items": ["Bolt Cutters"]
+        },
+        "item_object": "WP1000",
+        "parent_object": "WP1000",
+        "folder_path": "RopewayContents/World/Location_DownTown/LocationLevel_DownTown/LocationFsm_DownTown/S03_1000/ES_S03_1000/Item/ES_S03_1000/Weapon",
+        "randomized": 0   		
     },
     {
         "name": "Attache Case",
@@ -485,6 +552,15 @@
         "item_object": "sm70_100",
         "parent_object": "sm70_100",
         "folder_path": "RopewayContents/World/Location_DownTown/LocationLevel_DownTown/LocationFsm_DownTown/S03_1000/ES_S03_1000/Item/ES_S03_1000/I_700_Garage"
+    },
+    {
+        "name": "Breakable Box",
+        "region": "Back Alley",
+        "original_item": "Gunpowder",
+        "condition": {},
+        "item_object": "sm70_205",
+        "parent_object": "ItemPositions",
+        "folder_path": "RopewayContents/World/Location_DownTown/Environments/st03_0226_0/gimmick"		  
     },
     {
         "name": "Left Locker",
@@ -609,6 +685,24 @@
         "randomized": 0
     },
     {
+        "name": "Breakable Box",
+        "region": "Outdoor Area",
+        "original_item": "Handgun Ammo",
+        "condition": {},
+        "item_object": "sm70_100",
+        "parent_object": "ItemPositions",
+        "folder_path": "RopewayContents/World/Location_DownTown/Environments/st03_0402_0/gimmick",
+        "allow_item": [
+            "Battery Pack",
+            "Kendo Gate Key",
+            "Locker Room Key",
+            "Tape Player",
+            "Fuse 1",
+            "Fuse 2",
+            "Fuse 3"
+        ]  
+    },
+    {
         "name": "By Portable Generator",
         "region": "Power Maze",
         "original_item": "Green Herb",
@@ -645,14 +739,31 @@
         ]
     },
     {
+        "name": "Breakable Box",
+        "region": "Power Maze",
+        "original_item": "Handgun Ammo",
+        "condition": {},
+        "item_object": "sm70_100",
+        "parent_object": "ItemPositions",
+        "folder_path": "RopewayContents/World/Location_DownTown/Environments/st03_0402_0/gimmick",
+        "allow_item": [
+            "Battery Pack",
+            "Kendo Gate Key",
+            "Locker Room Key",
+            "Tape Player",
+            "Fuse 1",
+            "Fuse 2",
+            "Fuse 3"
+        ]
+    },
+    {
         "name": "1st Nemesis Case",
         "region": "Nemesis Chase",
         "original_item": "Supply Case - G19 Extended Mag",
         "condition": {},
         "item_object": "sm77_000",
         "parent_object": "sm77_000",
-        "folder_path": "RopewayContents/World/Location_DownTown/LocationLevel_DownTown/LocationFsm_DownTown/S03_1000/ES_S03_1000/Item/ES_S03_1000/NemesisDropItems",
-        "randomized": 0
+        "folder_path": "RopewayContents/World/Location_DownTown/LocationLevel_DownTown/LocationFsm_DownTown/S03_1000/ES_S03_1000/Item/ES_S03_1000/NemesisDropItems"
     },
     {
         "name": "2nd Nemesis Case",
@@ -661,8 +772,7 @@
         "condition": {},
         "item_object": "sm77_001",
         "parent_object": "sm77_001",
-        "folder_path": "RopewayContents/World/Location_DownTown/LocationLevel_DownTown/LocationFsm_DownTown/S03_1000/ES_S03_1000/Item/ES_S03_1000/NemesisDropItems",
-        "randomized": 0
+        "folder_path": "RopewayContents/World/Location_DownTown/LocationLevel_DownTown/LocationFsm_DownTown/S03_1000/ES_S03_1000/Item/ES_S03_1000/NemesisDropItems"
     },
     {
         "name": "3rd Nemesis Case",
@@ -671,8 +781,7 @@
         "condition": {},
         "item_object": "sm77_002",
         "parent_object": "sm77_002",
-        "folder_path": "RopewayContents/World/Location_DownTown/LocationLevel_DownTown/LocationFsm_DownTown/S03_1000/ES_S03_1000/Item/ES_S03_1000/NemesisDropItems",
-        "randomized": 0
+        "folder_path": "RopewayContents/World/Location_DownTown/LocationLevel_DownTown/LocationFsm_DownTown/S03_1000/ES_S03_1000/Item/ES_S03_1000/NemesisDropItems"
     },
     {
         "name": "Subway Access Passage",
@@ -681,16 +790,7 @@
         "condition": {},
         "item_object": "sm70_000",
         "parent_object": "sm70_000",
-        "folder_path": "RopewayContents/World/Location_DownTown/LocationLevel_DownTown/LocationFsm_DownTown/S03_1000/ES_S03_1000/Item/ES_S03_1000/I_100_Subway_Area/EmployeePassage",
-        "allow_item": [
-            "Battery Pack",
-            "Kendo Gate Key",
-            "Locker Room Key",
-            "Tape Player",
-            "Fuse 1",
-            "Fuse 2",
-            "Fuse 3"
-        ]
+        "folder_path": "RopewayContents/World/Location_DownTown/LocationLevel_DownTown/LocationFsm_DownTown/S03_1000/ES_S03_1000/Item/ES_S03_1000/I_100_Subway_Area/EmployeePassage"
     },
     {
         "name": "Subway Storeroom",
@@ -699,16 +799,7 @@
         "condition": {},
         "item_object": "sm70_100",
         "parent_object": "sm70_100",
-        "folder_path": "RopewayContents/World/Location_DownTown/LocationLevel_DownTown/LocationFsm_DownTown/S03_1000/ES_S03_1000/Item/ES_S03_1000/I_100_Subway_Area/EmployeePassage",
-        "allow_item": [
-            "Battery Pack",
-            "Kendo Gate Key",
-            "Locker Room Key",
-            "Tape Player",
-            "Fuse 1",
-            "Fuse 2",
-            "Fuse 3"
-        ]
+        "folder_path": "RopewayContents/World/Location_DownTown/LocationLevel_DownTown/LocationFsm_DownTown/S03_1000/ES_S03_1000/Item/ES_S03_1000/I_100_Subway_Area/EmployeePassage"
     },
     {
         "name": "Table",
@@ -916,6 +1007,24 @@
         "item_object": "sm73_305",
         "parent_object": "sm73_305",
         "folder_path": "RopewayContents/World/Location_DownTown/LocationLevel_DownTown/LocationFsm_DownTown/S03_1000/ES_S03_1000/Item/ES_S03_1000/KeyItem",
+        "allow_item": [
+            "Battery Pack",
+            "Kendo Gate Key",
+            "Locker Room Key",
+            "Tape Player",
+            "Fuse 1",
+            "Fuse 2",
+            "Fuse 3"
+        ]
+    },
+    {
+        "name": "Breakable Box",
+        "region": "Northwest Tunnel",
+        "original_item": "Gunpowder",
+        "condition": {},
+        "item_object": "sm70_205",
+        "parent_object": "ItemPositions",
+        "folder_path": "RopewayContents/World/Location_DownTown/Environments/st03_0611_0/gimmick",
         "allow_item": [
             "Battery Pack",
             "Kendo Gate Key",
@@ -1330,6 +1439,15 @@
         ]
     },
     {
+        "name": "Breakable Box",
+        "region": "Scaffolding",
+        "original_item": "First Aid Spray",
+        "condition": {},
+        "item_object": "sm70_000",
+        "parent_object": "ItemPositions",
+        "folder_path": "RopewayContents/World/Location_DownTown/Environments/st03_0228_0/gimmick"		
+    },
+    {
         "name": "4th Nemesis Case",
         "region": "Shopping Plaza",
         "original_item": "Supply Case - Flame Rounds",
@@ -1344,8 +1462,16 @@
         },
         "item_object": "sm77_004",
         "parent_object": "sm77_004",
-        "folder_path": "RopewayContents/World/Location_DownTown/LocationLevel_DownTown/LocationFsm_DownTown/S03_1000/ES_S03_1000/Item/ES_S03_1000/NemesisDropItems",
-        "randomized": 0
+        "folder_path": "RopewayContents/World/Location_DownTown/LocationLevel_DownTown/LocationFsm_DownTown/S03_1000/ES_S03_1000/Item/ES_S03_1000/NemesisDropItems"
+    },
+    {
+        "name": "Breakable Box",
+        "region": "East Courtyard",
+        "original_item": "Assault Rifle Ammo",
+        "condition": {},
+        "item_object": "sm70_102",
+        "parent_object": "ItemPositions",
+        "folder_path": "RopewayContents/World/Location_RPD/Environments/st02_0301_0/gimmick_Escape"
     },
     {
         "name": "Near Breakable Box",
@@ -1363,8 +1489,7 @@
         "condition": {},
         "item_object": "sm73_203",
         "parent_object": "sm73_203",
-        "folder_path": "RopewayManagers/TemporaryObjects/Enemy",
-        "randomized": 0
+        "folder_path": "RopewayManagers/TemporaryObjects/Enemy"
     },
     {
         "name": "Crates near Medallion Statue",
@@ -1435,6 +1560,22 @@
         "item_object": "sm70_102",
         "parent_object": "sm70_102",
         "folder_path": "RopewayContents/World/Location_RPD/LocationLevel_RPD/Item/common/ES_common",
+        "allow_item": [
+            "Locker Room Key",
+            "Tape Player",
+            "Fuse 1",
+            "Fuse 2",
+            "Fuse 3"
+        ]
+    },
+    {
+        "name": "Breakable Box",
+        "region": "West Hallway 1F",
+        "original_item": "Green Herb",
+        "condition": {},
+        "item_object": "sm70_001",
+        "parent_object": "ItemPositions",
+        "folder_path": "RopewayContents/World/Location_RPD/Environments/st02_0217_0/gimmick_Escape",
         "allow_item": [
             "Locker Room Key",
             "Tape Player",
@@ -1555,6 +1696,22 @@
         "item_object": "sm70_102",
         "parent_object": "ItemPositions_NormalLocker_1FW1DarkRoom",
         "folder_path": "RopewayContents/World/Location_RPD/LocationLevel_RPD/LocationFsm_RPD/common/ES_common/GeneralPurposeGimmicks/OpenLocker",
+        "allow_item": [
+            "Locker Room Key",
+            "Tape Player",
+            "Fuse 1",
+            "Fuse 2",
+            "Fuse 3"
+        ]
+    },
+    {
+        "name": "Breakable Box",
+        "region": "West Hallway 3F",
+        "original_item": "First Aid Spray",
+        "condition": {},
+        "item_object": "sm70_000",
+        "parent_object": "ItemPositions",
+        "folder_path": "RopewayContents/World/Location_RPD/Environments/st02_0603_0/gimmick_Escape",
         "allow_item": [
             "Locker Room Key",
             "Tape Player",
@@ -1830,8 +1987,7 @@
         "condition": {},
         "item_object": "sm70_100",
         "parent_object": "sm70_100hgsell",
-        "folder_path": "RopewayContents/World/Location_ClockTower/LocationLevel_ClockTower/Item",
-        "randomized": 0
+        "folder_path": "RopewayContents/World/Location_ClockTower/LocationLevel_ClockTower/Item"
     },
     {
         "name": "Bench near Statues",
@@ -1840,8 +1996,34 @@
         "condition": {},
         "item_object": "sm70_001",
         "parent_object": "sm70_001gherb",
-        "folder_path": "RopewayContents/World/Location_ClockTower/LocationLevel_ClockTower/Item",
-        "randomized": 0
+        "folder_path": "RopewayContents/World/Location_ClockTower/LocationLevel_ClockTower/Item"
+    },
+    {
+        "name": "Breakable Box ",
+        "region": "Promenade",
+        "original_item": "Red Herb",
+        "condition": {},
+        "item_object": "sm70_002",
+        "parent_object": "ItemPositions",
+        "folder_path": "RopewayContents/World/Location_ClockTower/Environments/st03_0804_0/gimmick"
+    },
+    {
+        "name": "Breakable Box 1",
+        "region": "Plaza",
+        "original_item": "Red Herb",
+        "condition": {},
+        "item_object": "sm70_002",
+        "parent_object": "ItemPositions",
+        "folder_path": "RopewayContents/World/Location_ClockTower/Environments/st03_0806_0/gimmick"
+    },
+    {
+        "name": "Breakable Box 2",
+        "region": "Plaza",
+        "original_item": "Green Herb",
+        "condition": {},
+        "item_object": "sm70_001",
+        "parent_object": "ItemPositions",
+        "folder_path": "RopewayContents/World/Location_ClockTower/Environments/st03_0806_0/gimmick"
     },
     {
         "name": "By School Bus 1",
@@ -1850,8 +2032,7 @@
         "condition": {},
         "item_object": "sm70_108",
         "parent_object": "sm70_108",
-        "folder_path": "RopewayContents/World/Location_ClockTower/LocationLevel_ClockTower/Item",
-        "randomized": 0
+        "folder_path": "RopewayContents/World/Location_ClockTower/LocationLevel_ClockTower/Item"
     },
     {
         "name": "By School Bus 2",
@@ -1860,8 +2041,7 @@
         "condition": {},
         "item_object": "sm70_100",
         "parent_object": "sm70_100hgshell_Car04A_01",
-        "folder_path": "RopewayContents/World/Location_ClockTower/LocationLevel_ClockTower/Item",
-        "randomized": 0
+        "folder_path": "RopewayContents/World/Location_ClockTower/LocationLevel_ClockTower/Item"
     },
     {
         "name": "Behind Statue",
@@ -1870,8 +2050,7 @@
         "condition": {},
         "item_object": "sm70_001",
         "parent_object": "sm70_001gherb",
-        "folder_path": "RopewayContents/World/Location_ClockTower/LocationLevel_ClockTower/Item",
-        "randomized": 0
+        "folder_path": "RopewayContents/World/Location_ClockTower/LocationLevel_ClockTower/Item"
     },
     {
         "name": "Inside Van",
@@ -1880,8 +2059,7 @@
         "condition": {},
         "item_object": "sm70_105",
         "parent_object": "sm70_105mine_Van04B_01",
-        "folder_path": "RopewayContents/World/Location_ClockTower/Environments/st03_0806_0/gimmick",
-        "randomized": 0
+        "folder_path": "RopewayContents/World/Location_ClockTower/Environments/st03_0806_0/gimmick"
     },
     {
         "name": "Inside Patrol Car",
@@ -1890,8 +2068,7 @@
         "condition": {},
         "item_object": "sm70_105",
         "parent_object": "sm70_105mine_Car01A_Ch3_2_00",
-        "folder_path": "RopewayContents/World/Location_ClockTower/Environments/st03_0806_0/gimmick",
-        "randomized": 0
+        "folder_path": "RopewayContents/World/Location_ClockTower/Environments/st03_0806_0/gimmick"
     },
     {
         "name": "By Bus 1",
@@ -1900,8 +2077,7 @@
         "condition": {},
         "item_object": "sm70_101",
         "parent_object": "sm70_101sgshell",
-        "folder_path": "RopewayContents/World/Location_ClockTower/LocationLevel_ClockTower/Item",
-        "randomized": 0
+        "folder_path": "RopewayContents/World/Location_ClockTower/LocationLevel_ClockTower/Item"
     },
     {
         "name": "By Bus 2",
@@ -1910,8 +2086,7 @@
         "condition": {},
         "item_object": "sm70_100",
         "parent_object": "sm70_100hgshell",
-        "folder_path": "RopewayContents/World/Location_ClockTower/LocationLevel_ClockTower/Item",
-        "randomized": 0
+        "folder_path": "RopewayContents/World/Location_ClockTower/LocationLevel_ClockTower/Item"
     },
     {
         "name": "Inside SWAT Truck",
@@ -1920,8 +2095,7 @@
         "condition": {},
         "item_object": "sm70_101",
         "parent_object": "sm70_101sgshell_Car01B_00",
-        "folder_path": "RopewayContents/World/Location_ClockTower/Environments/st03_0806_0/gimmick",
-        "randomized": 0
+        "folder_path": "RopewayContents/World/Location_ClockTower/Environments/st03_0806_0/gimmick"
     },
     {
         "name": "By Doors",
@@ -1976,6 +2150,15 @@
         "item_object": "sm70_001",
         "parent_object": "st04_0105_sm70_001_00",
         "folder_path": "RopewayContents/World/Location_Hospital/LocationLevel_Hospital/Item/common/st04_0105"
+    },
+    {
+        "name": "Breakable Box",
+        "region": "Emergency Entrance",
+        "original_item": "Handgun Ammo",
+        "condition": {},
+        "item_object": "sm70_100",
+        "parent_object": "ItemPositions",
+        "folder_path": "RopewayContents/World/Location_Hospital/Environments/st04_0107_0/gimmick"
     },
     {
         "name": "Table",
@@ -2242,7 +2425,15 @@
         "parent_object": "st04_0108_sm70_001_00",
         "folder_path": "RopewayContents/World/Location_Hospital/LocationLevel_Hospital/Item/common/st04_0108"
     },
-    
+    {
+        "name": "Breakable Box",
+        "region": "Emergency Entrance",
+        "original_item": "Green Herb",
+        "condition": {},
+        "item_object": "sm70_001",
+        "parent_object": "ItemPositions",
+        "folder_path": "RopewayContents/World/Location_Hospital/Environments/st04_0107_0/gimmick"
+    },
     {
         "name": "Desk 1",
         "region": "Research Laboratory",
@@ -2290,7 +2481,7 @@
         "randomized": 0
     },
     {
-        "name": "T-FAS",
+        "name": "Tyrell-FAS",
         "region": "Makeshift Sickroom",
         "original_item": "First Aid Spray",
         "condition": {},
@@ -2344,6 +2535,38 @@
         "item_object": "sm70_100",
         "parent_object": "st04_0101_sm70_100_01",
         "folder_path": "RopewayContents/World/Location_Hospital/LocationLevel_Hospital/Item/common/ES_common_Hospital2/Item/st04_0101",
+        "allow_item": [
+            "Fuse 1",
+            "Fuse 2",
+            "Fuse 3"
+        ]
+    },
+    {
+        "name": "Breakable Box near Sickroom",
+        "region": "Hospital Lobby",
+        "original_item": "Red Herb",
+        "condition": {
+            "items": ["Lock Pick", "Vaccine Sample"]
+        },
+        "item_object": "sm70_002",
+        "parent_object": "ItemPositions",
+        "folder_path": "RopewayContents/World/Location_Hospital/Environments/st04_0102_0/gimmick_Hospital2",
+        "allow_item": [
+            "Fuse 1",
+            "Fuse 2",
+            "Fuse 3"
+        ]		
+    },
+    {
+        "name": "Breakable Box near Reception",
+        "region": "Hospital Lobby",
+        "original_item": "Green Herb",
+        "condition": {
+            "items": ["Lock Pick", "Vaccine Sample"]
+        },
+        "item_object": "sm70_001",
+        "parent_object": "ItemPositions",
+        "folder_path": "RopewayContents/World/Location_Hospital/Environments/st04_0102_0/gimmick_Hospital2",
         "allow_item": [
             "Fuse 1",
             "Fuse 2",
@@ -2503,6 +2726,20 @@
         ]
     },
     {
+        "name": "Breakable Box",
+        "region": "Generator Room",
+        "original_item": "Handgun Ammo",
+        "condition": {},
+        "item_object": "sm70_100",
+        "parent_object": "ItemPositions",
+        "folder_path": "RopewayContents/World/Location_Hospital2/Environments/st04_0301_1/gimmick",
+        "allow_item": [
+            "Fuse 1",
+            "Fuse 2",
+            "Fuse 3"
+        ]		
+    },
+    {
         "name": "By Truck",
         "region": "Loading Bay",
         "original_item": "Explosive B",
@@ -2552,6 +2789,20 @@
         "item_object": "sm70_207",
         "parent_object": "st04_0403_02_sm70_207_00",
         "folder_path": "RopewayContents/World/Location_Hospital2/LocationLevel_Hospital2/Item/common/ES_common/st04_0403_02",
+        "allow_item": [
+            "Fuse 1",
+            "Fuse 2",
+            "Fuse 3"
+        ]
+    },
+    {
+        "name": "Breakable Box",
+        "region": "Warehouse",
+        "original_item": "Green Herb",
+        "condition": {},
+        "item_object": "sm70_001",
+        "parent_object": "ItemPositions",
+        "folder_path": "RopewayContents/World/Location_Hospital2/Environments/st04_0403_1/gimmick",
         "allow_item": [
             "Fuse 1",
             "Fuse 2",
@@ -3007,14 +3258,22 @@
         "folder_path": "RopewayContents/World/Location_Laboratory/LocationLevel_Laboratory/Item/common/ES_Common/03_Room01"
     },
     {
+        "name": "Breakable Box",
+        "region": "Worker's Break Room",
+        "original_item": "High-Grade Gunpowder",
+        "condition": {},
+        "item_object": "sm70_206",
+        "parent_object": "ItemPositions",
+        "folder_path": "RopewayContents/World/Location_Laboratory/Environments/st05_0202_0/gimmick"
+    },
+    {
         "name": "Attache Case",
         "region": "Disposable Chamber Walkway",
         "original_item": "Flame Rounds",
         "condition": {},
         "item_object": "sm70_108",
         "parent_object": "sm70_108_Acase",
-        "folder_path": "RopewayContents/World/Location_Laboratory/LocationLevel_Laboratory/Item/common/ES_Common/03_Room01",
-        "randomized": 0
+        "folder_path": "RopewayContents/World/Location_Laboratory/LocationLevel_Laboratory/Item/common/ES_Common/03_Room01"
     },
     {
         "name": "Amongst Waste 1",
@@ -3023,8 +3282,7 @@
         "condition": {},
         "item_object": "sm70_100",
         "parent_object": "sm70_100_HG",
-        "folder_path": "RopewayContents/World/Location_Laboratory/LocationLevel_Laboratory/Item/common/ES_Common/03_Room01",
-        "randomized": 0
+        "folder_path": "RopewayContents/World/Location_Laboratory/LocationLevel_Laboratory/Item/common/ES_Common/03_Room01"
     },
     {
         "name": "Amongst Waste 2",
@@ -3033,8 +3291,7 @@
         "condition": {},
         "item_object": "sm70_000",
         "parent_object": "sm70_000_Kyukyu",
-        "folder_path": "RopewayContents/World/Location_Laboratory/LocationLevel_Laboratory/Item/common/ES_Common/03_Room01",
-        "randomized": 0
+        "folder_path": "RopewayContents/World/Location_Laboratory/LocationLevel_Laboratory/Item/common/ES_Common/03_Room01"
     },
     {
         "name": "Amongst Waste 3",
@@ -3043,8 +3300,7 @@
         "condition": {},
         "item_object": "sm70_100",
         "parent_object": "sm70_100_HG",
-        "folder_path": "RopewayContents/World/Location_Laboratory/LocationLevel_Laboratory/Item/common/ES_Common/03_Room01",
-        "randomized": 0
+        "folder_path": "RopewayContents/World/Location_Laboratory/LocationLevel_Laboratory/Item/common/ES_Common/03_Room01"
     },
     {
         "name": "Amongst Waste 4",
@@ -3053,8 +3309,7 @@
         "condition": {},
         "item_object": "sm70_101",
         "parent_object": "sm70_101_SG",
-        "folder_path": "RopewayContents/World/Location_Laboratory/LocationLevel_Laboratory/Item/common/ES_Common/03_Room01",
-        "randomized": 0
+        "folder_path": "RopewayContents/World/Location_Laboratory/LocationLevel_Laboratory/Item/common/ES_Common/03_Room01"
     },
     {
         "name": "Near Typewriter",

--- a/residentevil3remake/data/jill/a/locations.json
+++ b/residentevil3remake/data/jill/a/locations.json
@@ -76,25 +76,6 @@
         ]
     },
     {
-        "name": "Breakable Box",
-        "region": "Subway Station",
-        "original_item": "Red Herb",
-        "condition": {},
-        "item_object": "sm70_002",
-        "parent_object": "ItemPositions",
-        "folder_path": "RopewayContents/World/Location_DownTown/Environments/st03_0201_0/gimmick",
-        "allow_item": [
-            "Fire Hose",
-            "Battery Pack",
-            "Kendo Gate Key",
-            "Locker Room Key",
-            "Tape Player",
-            "Fuse 1",
-            "Fuse 2",
-            "Fuse 3"
-        ]
-    },
-    {
         "name": "Attache Case",
         "region": "Subway Station",
         "original_item": "Shotgun Shells",
@@ -171,15 +152,6 @@
         "folder_path": "RopewayContents/World/Location_DownTown/LocationLevel_DownTown/LocationFsm_DownTown/S03_1000/ES_S03_1000/Item/ES_S03_1000/I_100_Subway_Area"
     },
     {
-        "name": "Breakable Box",
-        "region": "Main Avenue",
-        "original_item": "Gunpowder",
-        "condition": {},
-        "item_object": "sm70_205",
-        "parent_object": "ItemPositions",
-        "folder_path": "RopewayContents/World/Location_DownTown/Environments/st03_0208_0/gimmick"  
-    },
-    {
         "name": "Counter",
         "region": "Toy Shop",
         "original_item": "Fancy Box - Green Jewel",
@@ -224,15 +196,6 @@
         "parent_object": "sm70_205",
         "folder_path": "RopewayContents/World/Location_DownTown/LocationLevel_DownTown/LocationFsm_DownTown/S03_1000/ES_S03_1000/Item/ES_S03_1000/I_300_DounutShop_Area"
     },
-    {
-        "name": "Breakable Box",
-        "region": "Building Rooftop",
-        "original_item": "Green Herb",
-        "condition": {},
-        "item_object": "sm70_001",
-        "parent_object": "ItemPositions",
-        "folder_path": "RopewayContents/World/Location_DownTown/Environments/st03_0213_0/gimmick"		
-    }, 
     {
         "name": "Downed Zombie",
         "region": "Building Rooftop",
@@ -327,8 +290,7 @@
         "condition": {},
         "item_object": "0232_sm42_019_SafeBoxDial01A_00_control",
         "parent_object": "",
-        "folder_path": "RopewayContents/World/Location_DownTown/LocationLevel_DownTown/LocationFsm_DownTown/S03_1000/ES_S03_1000/SafeBox",
-        "randomized": 0
+        "folder_path": "RopewayContents/World/Location_DownTown/LocationLevel_DownTown/LocationFsm_DownTown/S03_1000/ES_S03_1000/SafeBox"
     },
     {
         "name": "In Drawer by Safe",
@@ -346,25 +308,7 @@
         "condition": {},
         "item_object": "sm70_100",
         "parent_object": "sm70_100_hgsehll",
-        "folder_path": "RopewayContents/World/Location_DownTown/LocationLevel_DownTown/LocationFsm_DownTown/S03_1000/ES_S03_1000/Item/ES_S03_1000/I_500_Owner_House"  
-    },
-    {
-        "name": "North Side Breakable Box",
-        "region": "Business Street",
-        "original_item": "Green Herb",
-        "condition": {},
-        "item_object": "sm70_001",
-        "parent_object": "ItemPositions",
-        "folder_path": "RopewayContents/World/Location_DownTown/Environments/st03_0219_0/gimmick"		  
-    },
-    {
-        "name": "South Side Breakable Box",
-        "region": "Business Street",
-        "original_item": "Gunpowder",
-        "condition": {},
-        "item_object": "sm70_205",
-        "parent_object": "ItemPositions",
-        "folder_path": "RopewayContents/World/Location_DownTown/Environments/st03_0219_0/gimmick"		  
+        "folder_path": "RopewayContents/World/Location_DownTown/LocationLevel_DownTown/LocationFsm_DownTown/S03_1000/ES_S03_1000/Item/ES_S03_1000/I_500_Owner_House"
     },
     {
         "name": "Table Next to Donut Shop",
@@ -443,16 +387,17 @@
         "folder_path": "RopewayContents/World/Location_DownTown/LocationLevel_DownTown/LocationFsm_DownTown/S03_1000/ES_S03_1000/Item/ES_S03_1000/I_600_ControlStation_Area/I_ControlRoom"
     },
     {
-        "name": "In Case of Emergency",
+        "name": "In Case Of Emergency",
         "region": "Subway Office",
-        "original_item": "M3",
+        "original_item": "M3 Shotgun",
         "condition": {
-            "items": ["Bolt Cutters"]
+            "items": [
+                "Bolt Cutters"
+            ]
         },
         "item_object": "WP1000",
         "parent_object": "WP1000",
-        "folder_path": "RopewayContents/World/Location_DownTown/LocationLevel_DownTown/LocationFsm_DownTown/S03_1000/ES_S03_1000/Item/ES_S03_1000/Weapon",
-        "randomized": 0   		
+        "folder_path": "RopewayContents/World/Location_DownTown/LocationLevel_DownTown/LocationFsm_DownTown/S03_1000/ES_S03_1000/Item/ES_S03_1000/Weapon"
     },
     {
         "name": "Attache Case",
@@ -552,15 +497,6 @@
         "item_object": "sm70_100",
         "parent_object": "sm70_100",
         "folder_path": "RopewayContents/World/Location_DownTown/LocationLevel_DownTown/LocationFsm_DownTown/S03_1000/ES_S03_1000/Item/ES_S03_1000/I_700_Garage"
-    },
-    {
-        "name": "Breakable Box",
-        "region": "Back Alley",
-        "original_item": "Gunpowder",
-        "condition": {},
-        "item_object": "sm70_205",
-        "parent_object": "ItemPositions",
-        "folder_path": "RopewayContents/World/Location_DownTown/Environments/st03_0226_0/gimmick"		  
     },
     {
         "name": "Left Locker",
@@ -685,24 +621,6 @@
         "randomized": 0
     },
     {
-        "name": "Breakable Box",
-        "region": "Outdoor Area",
-        "original_item": "Handgun Ammo",
-        "condition": {},
-        "item_object": "sm70_100",
-        "parent_object": "ItemPositions",
-        "folder_path": "RopewayContents/World/Location_DownTown/Environments/st03_0402_0/gimmick",
-        "allow_item": [
-            "Battery Pack",
-            "Kendo Gate Key",
-            "Locker Room Key",
-            "Tape Player",
-            "Fuse 1",
-            "Fuse 2",
-            "Fuse 3"
-        ]  
-    },
-    {
         "name": "By Portable Generator",
         "region": "Power Maze",
         "original_item": "Green Herb",
@@ -728,24 +646,6 @@
         "item_object": "sm70_001",
         "parent_object": "sm70_001",
         "folder_path": "RopewayContents/World/Location_DownTown/LocationLevel_DownTown/LocationFsm_DownTown/S03_1000/ES_S03_1000/Item/ES_S03_1000/I_800_Substaion_Area/I_Deimos_Area",
-        "allow_item": [
-            "Battery Pack",
-            "Kendo Gate Key",
-            "Locker Room Key",
-            "Tape Player",
-            "Fuse 1",
-            "Fuse 2",
-            "Fuse 3"
-        ]
-    },
-    {
-        "name": "Breakable Box",
-        "region": "Power Maze",
-        "original_item": "Handgun Ammo",
-        "condition": {},
-        "item_object": "sm70_100",
-        "parent_object": "ItemPositions",
-        "folder_path": "RopewayContents/World/Location_DownTown/Environments/st03_0402_0/gimmick",
         "allow_item": [
             "Battery Pack",
             "Kendo Gate Key",
@@ -1007,24 +907,6 @@
         "item_object": "sm73_305",
         "parent_object": "sm73_305",
         "folder_path": "RopewayContents/World/Location_DownTown/LocationLevel_DownTown/LocationFsm_DownTown/S03_1000/ES_S03_1000/Item/ES_S03_1000/KeyItem",
-        "allow_item": [
-            "Battery Pack",
-            "Kendo Gate Key",
-            "Locker Room Key",
-            "Tape Player",
-            "Fuse 1",
-            "Fuse 2",
-            "Fuse 3"
-        ]
-    },
-    {
-        "name": "Breakable Box",
-        "region": "Northwest Tunnel",
-        "original_item": "Gunpowder",
-        "condition": {},
-        "item_object": "sm70_205",
-        "parent_object": "ItemPositions",
-        "folder_path": "RopewayContents/World/Location_DownTown/Environments/st03_0611_0/gimmick",
         "allow_item": [
             "Battery Pack",
             "Kendo Gate Key",
@@ -1439,15 +1321,6 @@
         ]
     },
     {
-        "name": "Breakable Box",
-        "region": "Scaffolding",
-        "original_item": "First Aid Spray",
-        "condition": {},
-        "item_object": "sm70_000",
-        "parent_object": "ItemPositions",
-        "folder_path": "RopewayContents/World/Location_DownTown/Environments/st03_0228_0/gimmick"		
-    },
-    {
         "name": "4th Nemesis Case",
         "region": "Shopping Plaza",
         "original_item": "Supply Case - Flame Rounds",
@@ -1463,15 +1336,6 @@
         "item_object": "sm77_004",
         "parent_object": "sm77_004",
         "folder_path": "RopewayContents/World/Location_DownTown/LocationLevel_DownTown/LocationFsm_DownTown/S03_1000/ES_S03_1000/Item/ES_S03_1000/NemesisDropItems"
-    },
-    {
-        "name": "Breakable Box",
-        "region": "East Courtyard",
-        "original_item": "Assault Rifle Ammo",
-        "condition": {},
-        "item_object": "sm70_102",
-        "parent_object": "ItemPositions",
-        "folder_path": "RopewayContents/World/Location_RPD/Environments/st02_0301_0/gimmick_Escape"
     },
     {
         "name": "Near Breakable Box",
@@ -1569,22 +1433,6 @@
         ]
     },
     {
-        "name": "Breakable Box",
-        "region": "West Hallway 1F",
-        "original_item": "Green Herb",
-        "condition": {},
-        "item_object": "sm70_001",
-        "parent_object": "ItemPositions",
-        "folder_path": "RopewayContents/World/Location_RPD/Environments/st02_0217_0/gimmick_Escape",
-        "allow_item": [
-            "Locker Room Key",
-            "Tape Player",
-            "Fuse 1",
-            "Fuse 2",
-            "Fuse 3"
-        ]
-    },
-    {
         "name": "ID Case",
         "region": "West Office",
         "original_item": "Scope - Assault Rifle",
@@ -1595,8 +1443,7 @@
         },
         "item_object": "sm71_200",
         "parent_object": "ItemPositions_sm41_410",
-        "folder_path": "RopewayContents/World/Location_RPD/Environments/st02_0208_0/gimmick_Escape",
-        "randomized": 0
+        "folder_path": "RopewayContents/World/Location_RPD/Environments/st02_0208_0/gimmick_Escape"
     },
     {
         "name": "Locker",
@@ -1638,7 +1485,13 @@
         "item_object": "sm42_019_SafeBoxDial01A_OfficeW_control",
         "parent_object": "",
         "folder_path": "RopewayContents/World/Location_RPD/LocationLevel_RPD/LocationFsm_RPD/common/ES_common/1FW/WestOffice/IronSafe_1FWOffice",
-        "randomized": 0
+        "allow_item": [
+            "Locker Room Key",
+            "Tape Player",
+            "Fuse 1",
+            "Fuse 2",
+            "Fuse 3"
+        ]
     },
     {
         "name": "Cabinet near Reception Window",
@@ -1696,22 +1549,6 @@
         "item_object": "sm70_102",
         "parent_object": "ItemPositions_NormalLocker_1FW1DarkRoom",
         "folder_path": "RopewayContents/World/Location_RPD/LocationLevel_RPD/LocationFsm_RPD/common/ES_common/GeneralPurposeGimmicks/OpenLocker",
-        "allow_item": [
-            "Locker Room Key",
-            "Tape Player",
-            "Fuse 1",
-            "Fuse 2",
-            "Fuse 3"
-        ]
-    },
-    {
-        "name": "Breakable Box",
-        "region": "West Hallway 3F",
-        "original_item": "First Aid Spray",
-        "condition": {},
-        "item_object": "sm70_000",
-        "parent_object": "ItemPositions",
-        "folder_path": "RopewayContents/World/Location_RPD/Environments/st02_0603_0/gimmick_Escape",
         "allow_item": [
             "Locker Room Key",
             "Tape Player",
@@ -1965,6 +1802,22 @@
         ]
     },
     {
+        "name": "On Chair",
+        "region": "Dilapidated Shelter",
+        "original_item": "M3 Shotgun",
+        "condition": {},
+        "item_object": "WP1000",
+        "parent_object": "WP1000",
+        "folder_path": "RopewayContents/World/Location_ClockTower/LocationLevel_ClockTower/Item",
+        "allow_item": [
+            "Locker Room Key",
+            "Tape Player",
+            "Fuse 1",
+            "Fuse 2",
+            "Fuse 3"
+        ]
+    },
+    {
         "name": "On Barrel",
         "region": "Dilapidated Shelter",
         "original_item": "MGL Grenade Launcher",
@@ -1997,33 +1850,6 @@
         "item_object": "sm70_001",
         "parent_object": "sm70_001gherb",
         "folder_path": "RopewayContents/World/Location_ClockTower/LocationLevel_ClockTower/Item"
-    },
-    {
-        "name": "Breakable Box ",
-        "region": "Promenade",
-        "original_item": "Red Herb",
-        "condition": {},
-        "item_object": "sm70_002",
-        "parent_object": "ItemPositions",
-        "folder_path": "RopewayContents/World/Location_ClockTower/Environments/st03_0804_0/gimmick"
-    },
-    {
-        "name": "Breakable Box 1",
-        "region": "Plaza",
-        "original_item": "Red Herb",
-        "condition": {},
-        "item_object": "sm70_002",
-        "parent_object": "ItemPositions",
-        "folder_path": "RopewayContents/World/Location_ClockTower/Environments/st03_0806_0/gimmick"
-    },
-    {
-        "name": "Breakable Box 2",
-        "region": "Plaza",
-        "original_item": "Green Herb",
-        "condition": {},
-        "item_object": "sm70_001",
-        "parent_object": "ItemPositions",
-        "folder_path": "RopewayContents/World/Location_ClockTower/Environments/st03_0806_0/gimmick"
     },
     {
         "name": "By School Bus 1",
@@ -2152,15 +1978,6 @@
         "folder_path": "RopewayContents/World/Location_Hospital/LocationLevel_Hospital/Item/common/st04_0105"
     },
     {
-        "name": "Breakable Box",
-        "region": "Emergency Entrance",
-        "original_item": "Handgun Ammo",
-        "condition": {},
-        "item_object": "sm70_100",
-        "parent_object": "ItemPositions",
-        "folder_path": "RopewayContents/World/Location_Hospital/Environments/st04_0107_0/gimmick"
-    },
-    {
         "name": "Table",
         "region": "Emergency Entrance",
         "original_item": "Assault Rifle Ammo",
@@ -2230,8 +2047,7 @@
         "condition": {},
         "item_object": "0101_sm42_019_SafeBoxDial01A_control",
         "parent_object": "",
-        "folder_path": "RopewayContents/World/Location_Hospital/LocationLevel_Hospital/LocationFsm_Hospital/common/ES_common/SafeBox",
-        "randomized": 0
+        "folder_path": "RopewayContents/World/Location_Hospital/LocationLevel_Hospital/LocationFsm_Hospital/common/ES_common/SafeBox"
     },
     {
         "name": "Overbed Table 1",
@@ -2267,8 +2083,7 @@
         "condition": {},
         "item_object": "sm71_202",
         "parent_object": "st04_0113_sm71_202",
-        "folder_path": "RopewayContents/World/Location_Hospital/LocationLevel_Hospital/Item/common/ES_common/Item/st04_0113",
-        "randomized": 0
+        "folder_path": "RopewayContents/World/Location_Hospital/LocationLevel_Hospital/Item/common/ES_common/Item/st04_0113"
     },
     {
         "name": "Northwest Corner 1",
@@ -2424,16 +2239,7 @@
         "item_object": "sm70_001",
         "parent_object": "st04_0108_sm70_001_00",
         "folder_path": "RopewayContents/World/Location_Hospital/LocationLevel_Hospital/Item/common/st04_0108"
-    },
-    {
-        "name": "Breakable Box",
-        "region": "Emergency Entrance",
-        "original_item": "Green Herb",
-        "condition": {},
-        "item_object": "sm70_001",
-        "parent_object": "ItemPositions",
-        "folder_path": "RopewayContents/World/Location_Hospital/Environments/st04_0107_0/gimmick"
-    },
+    },    
     {
         "name": "Desk 1",
         "region": "Research Laboratory",
@@ -2535,38 +2341,6 @@
         "item_object": "sm70_100",
         "parent_object": "st04_0101_sm70_100_01",
         "folder_path": "RopewayContents/World/Location_Hospital/LocationLevel_Hospital/Item/common/ES_common_Hospital2/Item/st04_0101",
-        "allow_item": [
-            "Fuse 1",
-            "Fuse 2",
-            "Fuse 3"
-        ]
-    },
-    {
-        "name": "Breakable Box near Sickroom",
-        "region": "Hospital Lobby",
-        "original_item": "Red Herb",
-        "condition": {
-            "items": ["Lock Pick", "Vaccine Sample"]
-        },
-        "item_object": "sm70_002",
-        "parent_object": "ItemPositions",
-        "folder_path": "RopewayContents/World/Location_Hospital/Environments/st04_0102_0/gimmick_Hospital2",
-        "allow_item": [
-            "Fuse 1",
-            "Fuse 2",
-            "Fuse 3"
-        ]		
-    },
-    {
-        "name": "Breakable Box near Reception",
-        "region": "Hospital Lobby",
-        "original_item": "Green Herb",
-        "condition": {
-            "items": ["Lock Pick", "Vaccine Sample"]
-        },
-        "item_object": "sm70_001",
-        "parent_object": "ItemPositions",
-        "folder_path": "RopewayContents/World/Location_Hospital/Environments/st04_0102_0/gimmick_Hospital2",
         "allow_item": [
             "Fuse 1",
             "Fuse 2",
@@ -2726,20 +2500,6 @@
         ]
     },
     {
-        "name": "Breakable Box",
-        "region": "Generator Room",
-        "original_item": "Handgun Ammo",
-        "condition": {},
-        "item_object": "sm70_100",
-        "parent_object": "ItemPositions",
-        "folder_path": "RopewayContents/World/Location_Hospital2/Environments/st04_0301_1/gimmick",
-        "allow_item": [
-            "Fuse 1",
-            "Fuse 2",
-            "Fuse 3"
-        ]		
-    },
-    {
         "name": "By Truck",
         "region": "Loading Bay",
         "original_item": "Explosive B",
@@ -2789,20 +2549,6 @@
         "item_object": "sm70_207",
         "parent_object": "st04_0403_02_sm70_207_00",
         "folder_path": "RopewayContents/World/Location_Hospital2/LocationLevel_Hospital2/Item/common/ES_common/st04_0403_02",
-        "allow_item": [
-            "Fuse 1",
-            "Fuse 2",
-            "Fuse 3"
-        ]
-    },
-    {
-        "name": "Breakable Box",
-        "region": "Warehouse",
-        "original_item": "Green Herb",
-        "condition": {},
-        "item_object": "sm70_001",
-        "parent_object": "ItemPositions",
-        "folder_path": "RopewayContents/World/Location_Hospital2/Environments/st04_0403_1/gimmick",
         "allow_item": [
             "Fuse 1",
             "Fuse 2",
@@ -3033,6 +2779,15 @@
         "folder_path": "RopewayContents/World/Location_Laboratory/LocationLevel_Laboratory/Item/common/ES_Common/99_ReliefWeapon"
     },
     {
+        "name": "Near Item Box",
+        "region": "Laboratory Storage",
+        "original_item": "M3 Shotgun",
+        "condition": {},
+        "item_object": "WP1000",
+        "parent_object": "WP1000",
+        "folder_path": "RopewayContents/World/Location_Laboratory/LocationLevel_Laboratory/Item/common/ES_Common/99_ReliefWeapon"
+    },
+    {
         "name": "Floor by Door",
         "region": "Laboratory Storage",
         "original_item": "Green Herb",
@@ -3040,34 +2795,6 @@
         "item_object": "sm70_001",
         "parent_object": "sm70_001",
         "folder_path": "RopewayContents/World/Location_Laboratory/LocationLevel_Laboratory/Item/common/ES_Common/01_LockerRoom"
-    },
-    {
-        "name": "Storage",
-        "region": "Lab 1",
-        "original_item": "Culture Sample",
-        "condition": {},
-        "item_object": "st05_0107_sm41_426_ES_GrowthMachine01A_gimmick",
-        "parent_object": "",
-        "folder_path": "RopewayContents/World/Location_Laboratory/Environments/st05_0107_0/gimmick",
-        "randomized": 0
-    },
-    {
-        "name": "On Cart 1",
-        "region": "Lab 1",
-        "original_item": "Gunpowder",
-        "condition": {},
-        "item_object": "sm70_205",
-        "parent_object": "sm70_205",
-        "folder_path": "RopewayContents/World/Location_Laboratory/LocationLevel_Laboratory/Item/common/ES_Common/02_Laboratory"
-    },
-    {
-        "name": "On Cart 2",
-        "region": "Lab 1",
-        "original_item": "Handgun Ammo",
-        "condition": {},
-        "item_object": "sm70_100",
-        "parent_object": "sm70_100",
-        "folder_path": "RopewayContents/World/Location_Laboratory/LocationLevel_Laboratory/Item/common/ES_Common/02_Laboratory"
     },
     {
         "name": "Shelves",
@@ -3096,6 +2823,34 @@
         "parent_object": "",
         "folder_path": "RopewayContents/World/Location_Laboratory/Environments/st05_0108_0/gimmick",
         "randomized": 0
+    },
+    {
+        "name": "Storage",
+        "region": "Lab 1",
+        "original_item": "Culture Sample",
+        "condition": {},
+        "item_object": "st05_0107_sm41_426_ES_GrowthMachine01A_gimmick",
+        "parent_object": "",
+        "folder_path": "RopewayContents/World/Location_Laboratory/Environments/st05_0107_0/gimmick",
+        "randomized": 0
+    },
+    {
+        "name": "On Cart 1",
+        "region": "Lab 1",
+        "original_item": "Gunpowder",
+        "condition": {},
+        "item_object": "sm70_205",
+        "parent_object": "sm70_205",
+        "folder_path": "RopewayContents/World/Location_Laboratory/LocationLevel_Laboratory/Item/common/ES_Common/02_Laboratory"
+    },
+    {
+        "name": "On Cart 2",
+        "region": "Lab 1",
+        "original_item": "Handgun Ammo",
+        "condition": {},
+        "item_object": "sm70_100",
+        "parent_object": "sm70_100",
+        "folder_path": "RopewayContents/World/Location_Laboratory/LocationLevel_Laboratory/Item/common/ES_Common/02_Laboratory"
     },
     {
         "name": "On Box 1",
@@ -3256,15 +3011,6 @@
         "item_object": "sm70_000",
         "parent_object": "sm70_000",
         "folder_path": "RopewayContents/World/Location_Laboratory/LocationLevel_Laboratory/Item/common/ES_Common/03_Room01"
-    },
-    {
-        "name": "Breakable Box",
-        "region": "Worker's Break Room",
-        "original_item": "High-Grade Gunpowder",
-        "condition": {},
-        "item_object": "sm70_206",
-        "parent_object": "ItemPositions",
-        "folder_path": "RopewayContents/World/Location_Laboratory/Environments/st05_0202_0/gimmick"
     },
     {
         "name": "Attache Case",

--- a/residentevil3remake/data/jill/a/locations.json
+++ b/residentevil3remake/data/jill/a/locations.json
@@ -2791,34 +2791,6 @@
         "folder_path": "RopewayContents/World/Location_Laboratory/LocationLevel_Laboratory/Item/common/ES_Common/01_LockerRoom"
     },
     {
-        "name": "Shelves",
-        "region": "Experiment Room",
-        "original_item": "High-Grade Gunpowder",
-        "condition": {},
-        "item_object": "sm70_206",
-        "parent_object": "sm70_206",
-        "folder_path": "RopewayContents/World/Location_Laboratory/LocationLevel_Laboratory/Item/common/ES_Common/02_Laboratory"
-    },
-    {
-        "name": "By Corpse",
-        "region": "Experiment Room",
-        "original_item": "Handgun Ammo",
-        "condition": {},
-        "item_object": "sm70_100",
-        "parent_object": "sm70_100",
-        "folder_path": "RopewayContents/World/Location_Laboratory/LocationLevel_Laboratory/Item/common/ES_Common/02_Laboratory"
-    },
-    {
-        "name": "In Terminal",
-        "region": "Experiment Room",
-        "original_item": "Override Key",
-        "condition": {},
-        "item_object": "sm42_503_ES_LabMonitor04A_00_gimmick",
-        "parent_object": "",
-        "folder_path": "RopewayContents/World/Location_Laboratory/Environments/st05_0108_0/gimmick",
-        "randomized": 0
-    },
-    {
         "name": "Storage",
         "region": "Lab 1",
         "original_item": "Culture Sample",
@@ -2845,6 +2817,34 @@
         "item_object": "sm70_100",
         "parent_object": "sm70_100",
         "folder_path": "RopewayContents/World/Location_Laboratory/LocationLevel_Laboratory/Item/common/ES_Common/02_Laboratory"
+    },
+    {
+        "name": "Shelves",
+        "region": "Experiment Room",
+        "original_item": "High-Grade Gunpowder",
+        "condition": {},
+        "item_object": "sm70_206",
+        "parent_object": "sm70_206",
+        "folder_path": "RopewayContents/World/Location_Laboratory/LocationLevel_Laboratory/Item/common/ES_Common/02_Laboratory"
+    },
+    {
+        "name": "By Corpse",
+        "region": "Experiment Room",
+        "original_item": "Handgun Ammo",
+        "condition": {},
+        "item_object": "sm70_100",
+        "parent_object": "sm70_100",
+        "folder_path": "RopewayContents/World/Location_Laboratory/LocationLevel_Laboratory/Item/common/ES_Common/02_Laboratory"
+    },
+    {
+        "name": "In Terminal",
+        "region": "Experiment Room",
+        "original_item": "Override Key",
+        "condition": {},
+        "item_object": "sm42_503_ES_LabMonitor04A_00_gimmick",
+        "parent_object": "",
+        "folder_path": "RopewayContents/World/Location_Laboratory/Environments/st05_0108_0/gimmick",
+        "randomized": 0
     },
     {
         "name": "On Box 1",

--- a/residentevil3remake/data/jill/a/locations.json
+++ b/residentevil3remake/data/jill/a/locations.json
@@ -9,13 +9,16 @@
         "folder_path": "RopewayContents/World/Location_DownTown/LocationLevel_DownTown/LocationFsm_DownTown/S03_1000/ES_S03_1000/Item/ES_S03_1000/I_100_Subway_Area",
         "allow_item": [
             "Fire Hose",
+            "Lock Pick",
             "Battery Pack",
             "Kendo Gate Key",
             "Locker Room Key",
             "Tape Player",
             "Fuse 1",
             "Fuse 2",
-            "Fuse 3"
+            "Fuse 3",
+            "Override Key",
+            "Culture Sample"
         ]
     },
     {
@@ -28,13 +31,16 @@
         "folder_path": "RopewayContents/World/Location_DownTown/LocationLevel_DownTown/LocationFsm_DownTown/S03_1000/ES_S03_1000/Item/ES_S03_1000/I_100_Subway_Area",
         "allow_item": [
             "Fire Hose",
+            "Lock Pick",
             "Battery Pack",
             "Kendo Gate Key",
             "Locker Room Key",
             "Tape Player",
             "Fuse 1",
             "Fuse 2",
-            "Fuse 3"
+            "Fuse 3",
+            "Override Key",
+            "Culture Sample"
         ]
     },
     {
@@ -47,13 +53,16 @@
         "folder_path": "RopewayContents/World/Location_DownTown/LocationLevel_DownTown/LocationFsm_DownTown/S03_1000/ES_S03_1000/Item/ES_S03_1000/I_100_Subway_Area",
         "allow_item": [
             "Fire Hose",
+            "Lock Pick",
             "Battery Pack",
             "Kendo Gate Key",
             "Locker Room Key",
             "Tape Player",
             "Fuse 1",
             "Fuse 2",
-            "Fuse 3"
+            "Fuse 3",
+            "Override Key",
+            "Culture Sample"
         ]
     },
     {
@@ -66,13 +75,38 @@
         "folder_path": "RopewayContents/World/Location_DownTown/LocationLevel_DownTown/LocationFsm_DownTown/S03_1000/ES_S03_1000/Item/ES_S03_1000/I_100_Subway_Area",
         "allow_item": [
             "Fire Hose",
+            "Lock Pick",
             "Battery Pack",
             "Kendo Gate Key",
             "Locker Room Key",
             "Tape Player",
             "Fuse 1",
             "Fuse 2",
-            "Fuse 3"
+            "Fuse 3",
+            "Override Key",
+            "Culture Sample"
+        ]
+    },
+    {
+        "name": "Breakable Box",
+        "region": "Subway Station",
+        "original_item": "Red Herb",
+        "condition": {},
+        "item_object": "sm70_002",
+        "parent_object": "ItemPositions",
+        "folder_path": "RopewayContents/World/Location_DownTown/Environments/st03_0201_0/gimmick",
+        "allow_item": [
+            "Fire Hose",
+            "Lock Pick",
+            "Battery Pack",
+            "Kendo Gate Key",
+            "Locker Room Key",
+            "Tape Player",
+            "Fuse 1",
+            "Fuse 2",
+            "Fuse 3",
+            "Override Key",
+            "Culture Sample"
         ]
     },
     {
@@ -88,13 +122,17 @@
         "parent_object": "sm70_101",
         "folder_path": "RopewayContents/World/Location_DownTown/LocationLevel_DownTown/LocationFsm_DownTown/S03_1000/ES_S03_1000/Item/ES_S03_1000/I_100_Subway_Area",
         "allow_item": [
+            "Fire Hose",
+            "Lock Pick",
             "Battery Pack",
             "Kendo Gate Key",
             "Locker Room Key",
             "Tape Player",
             "Fuse 1",
             "Fuse 2",
-            "Fuse 3"
+            "Fuse 3",
+            "Override Key",
+            "Culture Sample"
         ]
     },
     {
@@ -152,58 +190,22 @@
         "folder_path": "RopewayContents/World/Location_DownTown/LocationLevel_DownTown/LocationFsm_DownTown/S03_1000/ES_S03_1000/Item/ES_S03_1000/I_100_Subway_Area"
     },
     {
-        "name": "Counter",
-        "region": "Toy Shop",
-        "original_item": "Fancy Box - Green Jewel",
+        "name": "Breakable Box",
+        "region": "Main Avenue",
+        "original_item": "Gunpowder",
         "condition": {},
-        "item_object": "sm73_311",
-        "parent_object": "sm73_311",
-        "folder_path": "RopewayContents/World/Location_DownTown/LocationLevel_DownTown/LocationFsm_DownTown/S03_1000/ES_S03_1000/Item/ES_S03_1000/KeyItem"
+        "item_object": "sm70_205",
+        "parent_object": "ItemPositions",
+        "folder_path": "RopewayContents/World/Location_DownTown/Environments/st03_0208_0/gimmick"
     },
     {
-        "name": "Counter by Door",
-        "region": "Supermarket",
-        "original_item": "Fancy Box - Blue Jewel",
-        "condition": {},
-        "item_object": "sm73_312",
-        "parent_object": "sm73_312",
-        "folder_path": "RopewayContents/World/Location_DownTown/LocationLevel_DownTown/LocationFsm_DownTown/S03_1000/ES_S03_1000/Item/ES_S03_1000/KeyItem"
-    },
-    {
-        "name": "North East Shelves",
-        "region": "Supermarket",
-        "original_item": "First Aid Spray",
-        "condition": {},
-        "item_object": "sm70_000",
-        "parent_object": "sm70_000",
-        "folder_path": "RopewayContents/World/Location_DownTown/LocationLevel_DownTown/LocationFsm_DownTown/S03_1000/ES_S03_1000/Item/ES_S03_1000/I_200_T-Junction_Area/I_205_SuperMarket"
-    },
-    {
-        "name": "Center Shelves",
-        "region": "Supermarket",
-        "original_item": "High-Grade Gunpowder",
-        "condition": {},
-        "item_object": "sm70_206",
-        "parent_object": "sm70_206",
-        "folder_path": "RopewayContents/World/Location_DownTown/LocationLevel_DownTown/LocationFsm_DownTown/S03_1000/ES_S03_1000/Item/ES_S03_1000/I_200_T-Junction_Area/I_205_SuperMarket"
-    },
-    {
-        "name": "Box by Donut Shop",
+        "name": "Box By Donut Shop",
         "region": "Shopping Plaza",
         "original_item": "Gunpowder",
         "condition": {},
         "item_object": "sm70_205",
         "parent_object": "sm70_205",
         "folder_path": "RopewayContents/World/Location_DownTown/LocationLevel_DownTown/LocationFsm_DownTown/S03_1000/ES_S03_1000/Item/ES_S03_1000/I_300_DounutShop_Area"
-    },
-    {
-        "name": "Downed Zombie",
-        "region": "Building Rooftop",
-        "original_item": "Gunpowder",
-        "condition": {},
-        "item_object": "sm70_205",
-        "parent_object": "sm70_205",
-        "folder_path": "RopewayContents/World/Location_DownTown/LocationLevel_DownTown/LocationFsm_DownTown/S03_1000/ES_S03_1000/Item/ES_S03_1000/I_400_Signboard_Area"
     },
     {
         "name": "By Coffee Machines",
@@ -215,35 +217,13 @@
         "folder_path": "RopewayContents/World/Location_DownTown/LocationLevel_DownTown/LocationFsm_DownTown/S03_1000/ES_S03_1000/Item/ES_S03_1000/I_300_DounutShop_Area/_DounutShop_Inside"
     },
     {
-        "name": "Table by Zombie Couple",
+        "name": "Table By Zombie Couple",
         "region": "Donut Shop",
         "original_item": "Gunpowder",
         "condition": {},
         "item_object": "sm70_205",
         "parent_object": "sm70_205",
         "folder_path": "RopewayContents/World/Location_DownTown/LocationLevel_DownTown/LocationFsm_DownTown/S03_1000/ES_S03_1000/Item/ES_S03_1000/I_300_DounutShop_Area/_DounutShop_Inside"
-    },
-    {
-        "name": "Locker",
-        "region": "Donut Shop",
-        "original_item": "Hand Grenade",
-        "condition": {
-            "items": [
-                "Lock Pick"
-            ]
-        },
-        "item_object": "WP6200",
-        "parent_object": "wp6200_grenade_In_LockedLocker",
-        "folder_path": "RopewayContents/World/Location_DownTown/LocationLevel_DownTown/LocationFsm_DownTown/S03_1000/ES_S03_1000/Item/ES_S03_1000/I_300_DounutShop_Area/_DounutShop_Inside",
-        "allow_item": [
-            "Battery Pack",
-            "Kendo Gate Key",
-            "Locker Room Key",
-            "Tape Player",
-            "Fuse 1",
-            "Fuse 2",
-            "Fuse 3"
-        ]
     },
     {
         "name": "Inside Kitchen 1",
@@ -255,13 +235,16 @@
         "folder_path": "RopewayContents/World/Location_DownTown/LocationLevel_DownTown/LocationFsm_DownTown/S03_1000/ES_S03_1000/Item/ES_S03_1000/I_300_DounutShop_Area/_DounutShop_Inside",
         "allow_item": [
             "Fire Hose",
+            "Lock Pick",
             "Battery Pack",
             "Kendo Gate Key",
             "Locker Room Key",
             "Tape Player",
             "Fuse 1",
             "Fuse 2",
-            "Fuse 3"
+            "Fuse 3",
+            "Override Key",
+            "Culture Sample"
         ]
     },
     {
@@ -274,41 +257,35 @@
         "folder_path": "RopewayContents/World/Location_DownTown/LocationLevel_DownTown/LocationFsm_DownTown/S03_1000/ES_S03_1000/Item/ES_S03_1000/KeyItem",
         "allow_item": [
             "Fire Hose",
+            "Lock Pick",
             "Battery Pack",
             "Kendo Gate Key",
             "Locker Room Key",
             "Tape Player",
             "Fuse 1",
             "Fuse 2",
-            "Fuse 3"
+            "Fuse 3",
+            "Override Key",
+            "Culture Sample"
         ]
     },
     {
-        "name": "Safe",
-        "region": "Drugstore Storage",
-        "original_item": "Dot Sight - G19",
-        "condition": {},
-        "item_object": "0232_sm42_019_SafeBoxDial01A_00_control",
-        "parent_object": "",
-        "folder_path": "RopewayContents/World/Location_DownTown/LocationLevel_DownTown/LocationFsm_DownTown/S03_1000/ES_S03_1000/SafeBox"
-    },
-    {
-        "name": "In Drawer by Safe",
-        "region": "Drugstore Storage",
-        "original_item": "Gunpowder",
-        "condition": {},
-        "item_object": "sm70_205",
-        "parent_object": "sm70_205_gunp_chestpos",
-        "folder_path": "RopewayContents/World/Location_DownTown/LocationLevel_DownTown/LocationFsm_DownTown/S03_1000/ES_S03_1000/Item/ES_S03_1000/I_500_Owner_House"
-    },
-    {
-        "name": "Storage Entry",
-        "region": "Drugstore Storage",
+        "name": "South Side Breakable Box",
+        "region": "Business Street",
         "original_item": "Handgun Ammo",
         "condition": {},
         "item_object": "sm70_100",
-        "parent_object": "sm70_100_hgsehll",
-        "folder_path": "RopewayContents/World/Location_DownTown/LocationLevel_DownTown/LocationFsm_DownTown/S03_1000/ES_S03_1000/Item/ES_S03_1000/I_500_Owner_House"
+        "parent_object": "ItemPositions",
+        "folder_path": "RopewayContents/World/Location_DownTown/Environments/st03_0219_0/gimmick"
+    },
+    {
+        "name": "North Side Breakable Box",
+        "region": "Business Street",
+        "original_item": "Handgun Ammo",
+        "condition": {},
+        "item_object": "sm70_100",
+        "parent_object": "ItemPositions",
+        "folder_path": "RopewayContents/World/Location_DownTown/Environments/st03_0216_0/gimmick"
     },
     {
         "name": "Table Next to Donut Shop",
@@ -320,33 +297,6 @@
         "folder_path": "RopewayContents/World/Location_DownTown/LocationLevel_DownTown/LocationFsm_DownTown/S03_1000/ES_S03_1000/Item/ES_S03_1000/I_600_ControlStation_Area/I_Street"
     },
     {
-        "name": "Table by Downed Zombie",
-        "region": "Pharmacy",
-        "original_item": "Handgun Ammo",
-        "condition": {},
-        "item_object": "sm70_100",
-        "parent_object": "sm70_100",
-        "folder_path": "RopewayContents/World/Location_DownTown/LocationLevel_DownTown/LocationFsm_DownTown/S03_1000/ES_S03_1000/Item/ES_S03_1000/I_600_ControlStation_Area/I_Pharamacy"
-    },
-    {
-        "name": "Shelves",
-        "region": "Pharmacy",
-        "original_item": "High-Grade Gunpowder",
-        "condition": {},
-        "item_object": "sm70_206",
-        "parent_object": "sm70_206_chemi",
-        "folder_path": "RopewayContents/World/Location_DownTown/LocationLevel_DownTown/LocationFsm_DownTown/S03_1000/ES_S03_1000/Item/ES_S03_1000/I_600_ControlStation_Area/I_Pharamacy"
-    },
-    {
-        "name": "Box by Register",
-        "region": "Pharmacy",
-        "original_item": "Green Herb",
-        "condition": {},
-        "item_object": "sm70_001",
-        "parent_object": "sm70_001_greenherb",
-        "folder_path": "RopewayContents/World/Location_DownTown/LocationLevel_DownTown/LocationFsm_DownTown/S03_1000/ES_S03_1000/Item/ES_S03_1000/I_600_ControlStation_Area/I_Pharamacy"
-    },
-    {
         "name": "Floor in Hallway",
         "region": "Subway Office",
         "original_item": "Fire Hose",
@@ -354,19 +304,6 @@
         "item_object": "sm74_203",
         "parent_object": "sm74_203",
         "folder_path": "RopewayContents/World/Location_DownTown/LocationLevel_DownTown/LocationFsm_DownTown/S03_1000/ES_S03_1000/Item/ES_S03_1000/KeyItem"
-    },
-    {
-        "name": "Left Locker",
-        "region": "Subway Office",
-        "original_item": "First Aid Spray",
-        "condition": {
-            "items": [
-                "Lock Pick"
-            ]
-        },
-        "item_object": "sm70_000",
-        "parent_object": "600_wp6200_grenade_01_In_LockedLocker",
-        "folder_path": "RopewayContents/World/Location_DownTown/LocationLevel_DownTown/LocationFsm_DownTown/S03_1000/ES_S03_1000/Item/ES_S03_1000/I_600_ControlStation_Area/I_ControlRoom"
     },
     {
         "name": "Middle Locker",
@@ -387,30 +324,412 @@
         "folder_path": "RopewayContents/World/Location_DownTown/LocationLevel_DownTown/LocationFsm_DownTown/S03_1000/ES_S03_1000/Item/ES_S03_1000/I_600_ControlStation_Area/I_ControlRoom"
     },
     {
-        "name": "In Case Of Emergency",
-        "region": "Subway Office",
-        "original_item": "M3 Shotgun",
-        "condition": {
-            "items": [
-                "Bolt Cutters"
-            ]
-        },
-        "item_object": "WP1000",
-        "parent_object": "WP1000",
-        "folder_path": "RopewayContents/World/Location_DownTown/LocationLevel_DownTown/LocationFsm_DownTown/S03_1000/ES_S03_1000/Item/ES_S03_1000/Weapon"
+        "name": "Table By Downed Zombie",
+        "region": "Pharmacy",
+        "original_item": "Handgun Ammo",
+        "condition": {},
+        "item_object": "sm70_100",
+        "parent_object": "sm70_100",
+        "folder_path": "RopewayContents/World/Location_DownTown/LocationLevel_DownTown/LocationFsm_DownTown/S03_1000/ES_S03_1000/Item/ES_S03_1000/I_600_ControlStation_Area/I_Pharamacy"
     },
     {
-        "name": "Attache Case",
-        "region": "Subway Office",
+        "name": "Shelves",
+        "region": "Pharmacy",
+        "original_item": "High-Grade Gunpowder",
+        "condition": {},
+        "item_object": "sm70_206",
+        "parent_object": "sm70_206_chemi",
+        "folder_path": "RopewayContents/World/Location_DownTown/LocationLevel_DownTown/LocationFsm_DownTown/S03_1000/ES_S03_1000/Item/ES_S03_1000/I_600_ControlStation_Area/I_Pharamacy"
+    },
+    {
+        "name": "Box By Register",
+        "region": "Pharmacy",
+        "original_item": "Green Herb",
+        "condition": {},
+        "item_object": "sm70_001",
+        "parent_object": "sm70_001_greenherb",
+        "folder_path": "RopewayContents/World/Location_DownTown/LocationLevel_DownTown/LocationFsm_DownTown/S03_1000/ES_S03_1000/Item/ES_S03_1000/I_600_ControlStation_Area/I_Pharamacy"
+    },
+    {
+        "name": "Safe",
+        "region": "Drugstore Storage",
+        "original_item": "Dot Sight - G19",
+        "condition": {},
+        "item_object": "0232_sm42_019_SafeBoxDial01A_00_control",
+        "parent_object": "",
+        "folder_path": "RopewayContents/World/Location_DownTown/LocationLevel_DownTown/LocationFsm_DownTown/S03_1000/ES_S03_1000/SafeBox"
+    },
+    {
+        "name": "In Drawer By Safe",
+        "region": "Drugstore Storage",
+        "original_item": "Gunpowder",
+        "condition": {},
+        "item_object": "sm70_205",
+        "parent_object": "sm70_205_gunp_chestpos",
+        "folder_path": "RopewayContents/World/Location_DownTown/LocationLevel_DownTown/LocationFsm_DownTown/S03_1000/ES_S03_1000/Item/ES_S03_1000/I_500_Owner_House"
+    },
+    {
+        "name": "Storage Entry",
+        "region": "Drugstore Storage",
+        "original_item": "Handgun Ammo",
+        "condition": {},
+        "item_object": "sm70_100",
+        "parent_object": "sm70_100_hgsehll",
+        "folder_path": "RopewayContents/World/Location_DownTown/LocationLevel_DownTown/LocationFsm_DownTown/S03_1000/ES_S03_1000/Item/ES_S03_1000/I_500_Owner_House"
+    },
+    {
+        "name": "Breakable Box",
+        "region": "Building Rooftop",
+        "original_item": "Handgun Ammo",
+        "condition": {},
+        "item_object": "sm70_100",
+        "parent_object": "ItemPositions",
+        "folder_path": "RopewayContents/World/Location_DownTown/Environments/st03_0213_0/gimmick"
+    },
+    {
+        "name": "Downed Zombie",
+        "region": "Building Rooftop",
+        "original_item": "Gunpowder",
+        "condition": {},
+        "item_object": "sm70_205",
+        "parent_object": "sm70_205",
+        "folder_path": "RopewayContents/World/Location_DownTown/LocationLevel_DownTown/LocationFsm_DownTown/S03_1000/ES_S03_1000/Item/ES_S03_1000/I_400_Signboard_Area"
+    },
+    {
+        "name": "Tool Cabinet",
+        "region": "Tool Shop",
+        "original_item": "Bolt Cutters",
+        "condition": {},
+        "item_object": "sm73_001",
+        "parent_object": "sm73_001",
+        "folder_path": "RopewayContents/World/Location_DownTown/LocationLevel_DownTown/LocationFsm_DownTown/S03_1000/ES_S03_1000/Item/ES_S03_1000/KeyItem",
+        "randomized": 0
+    },
+    {
+        "name": "On Table",
+        "region": "Garage",
         "original_item": "Shotgun Shells",
+        "condition": {},
+        "item_object": "sm70_101",
+        "parent_object": "sm70_101_sgshell",
+        "folder_path": "RopewayContents/World/Location_DownTown/LocationLevel_DownTown/LocationFsm_DownTown/S03_1000/ES_S03_1000/Item/ES_S03_1000/I_700_Garage",
+        "allow_item": [
+            "Battery Pack",
+            "Kendo Gate Key",
+            "Locker Room Key",
+            "Tape Player",
+            "Fuse 1",
+            "Fuse 2",
+            "Fuse 3",
+            "Override Key",
+            "Culture Sample"
+        ]
+    },
+    {
+        "name": "Downed UCBS Merc",
+        "region": "Back Alley",
+        "original_item": "Handgun Ammo",
+        "condition": {},
+        "item_object": "sm70_100",
+        "parent_object": "sm70_100",
+        "folder_path": "RopewayContents/World/Location_DownTown/LocationLevel_DownTown/LocationFsm_DownTown/S03_1000/ES_S03_1000/Item/ES_S03_1000/I_700_Garage"
+    },
+    {
+        "name": "Breakable Box",
+        "region": "Back Alley",
+        "original_item": "Handgun Ammo",
+        "condition": {},
+        "item_object": "sm70_100",
+        "parent_object": "ItemPositions",
+        "folder_path": "RopewayContents/World/Location_DownTown/Environments/st03_0226_0/gimmick"
+    },
+    {
+        "name": "Right Locker",
+        "region": "Substation",
+        "original_item": "Gunpowder",
+        "condition": {},
+        "item_object": "sm70_205",
+        "parent_object": "sm70_205_gunp_Locker",
+        "folder_path": "RopewayContents/World/Location_DownTown/LocationLevel_DownTown/LocationFsm_DownTown/S03_1000/ES_S03_1000/Item/ES_S03_1000/I_800_Substaion_Area/I_Building_Inside",
+        "allow_item": [
+            "Lock Pick",
+            "Battery Pack",
+            "Kendo Gate Key",
+            "Locker Room Key",
+            "Tape Player",
+            "Fuse 1",
+            "Fuse 2",
+            "Fuse 3",
+            "Override Key",
+            "Culture Sample"
+        ]
+    },
+    {
+        "name": "Table",
+        "region": "Substation",
+        "original_item": "Red Herb",
+        "condition": {},
+        "item_object": "sm70_002",
+        "parent_object": "sm70_002_rherb",
+        "folder_path": "RopewayContents/World/Location_DownTown/LocationLevel_DownTown/LocationFsm_DownTown/S03_1000/ES_S03_1000/Item/ES_S03_1000/I_800_Substaion_Area/I_Building_Inside",
+        "allow_item": [
+            "Lock Pick",
+            "Battery Pack",
+            "Kendo Gate Key",
+            "Locker Room Key",
+            "Tape Player",
+            "Fuse 1",
+            "Fuse 2",
+            "Fuse 3",
+            "Override Key",
+            "Culture Sample"
+        ]
+    },
+    {
+        "name": "Control Room",
+        "region": "Substation",
+        "original_item": "Hip Pouch",
+        "condition": {},
+        "item_object": "sm74_200",
+        "parent_object": "sm74_200_SideBag",
+        "folder_path": "RopewayContents/World/Location_DownTown/LocationLevel_DownTown/LocationFsm_DownTown/S03_1000/ES_S03_1000/Item/ES_S03_1000/I_800_Substaion_Area/I_Building_Inside",
+        "allow_item": [
+            "Lock Pick",
+            "Battery Pack",
+            "Kendo Gate Key",
+            "Locker Room Key",
+            "Tape Player",
+            "Fuse 1",
+            "Fuse 2",
+            "Fuse 3",
+            "Override Key",
+            "Culture Sample"
+        ]
+    },
+    {
+        "name": "Storage Racks 1",
+        "region": "Outdoor Area",
+        "original_item": "Green Herb",
+        "condition": {},
+        "item_object": "sm70_001",
+        "parent_object": "sm70_001",
+        "folder_path": "RopewayContents/World/Location_DownTown/LocationLevel_DownTown/LocationFsm_DownTown/S03_1000/ES_S03_1000/Item/ES_S03_1000/I_800_Substaion_Area/I_Deimos_Area/HerbPlanter",
+        "allow_item": [
+            "Lock Pick",
+            "Battery Pack",
+            "Kendo Gate Key",
+            "Locker Room Key",
+            "Tape Player",
+            "Fuse 1",
+            "Fuse 2",
+            "Fuse 3",
+            "Override Key",
+            "Culture Sample"
+        ]
+    },
+    {
+        "name": "Storage Racks 2",
+        "region": "Outdoor Area",
+        "original_item": "Green Herb",
+        "condition": {},
+        "item_object": "sm70_001",
+        "parent_object": "sm70_001",
+        "folder_path": "RopewayContents/World/Location_DownTown/LocationLevel_DownTown/LocationFsm_DownTown/S03_1000/ES_S03_1000/Item/ES_S03_1000/I_800_Substaion_Area/I_Deimos_Area/HerbPlanter",
+        "allow_item": [
+            "Lock Pick",
+            "Battery Pack",
+            "Kendo Gate Key",
+            "Locker Room Key",
+            "Tape Player",
+            "Fuse 1",
+            "Fuse 2",
+            "Fuse 3",
+            "Override Key",
+            "Culture Sample"
+        ]
+    },
+    {
+        "name": "Corpse",
+        "region": "Outdoor Area",
+        "original_item": "Lock Pick",
+        "condition": {},
+        "item_object": "EventPlay_EV322_k",
+        "parent_object": "",
+        "folder_path": "RopewayContents/World/Location_DownTown/LocationLevel_DownTown/Scenario/S03_1000/ES_S03_1000",
+        "allow_item": [
+            "Lock Pick",
+            "Battery Pack",
+            "Kendo Gate Key",
+            "Locker Room Key",
+            "Tape Player",
+            "Fuse 1",
+            "Fuse 2",
+            "Fuse 3",
+            "Override Key",
+            "Culture Sample"
+        ]
+    },
+    {
+        "name": "Breakable Box",
+        "region": "Outdoor Area",
+        "original_item": "Handgun Ammo",
+        "condition": {},
+        "item_object": "sm70_100",
+        "parent_object": "ItemPositions",
+        "folder_path": "RopewayContents/World/Location_DownTown/Environments/st03_0402_0/gimmick",
+        "allow_item": [
+            "Lock Pick",
+            "Battery Pack",
+            "Kendo Gate Key",
+            "Locker Room Key",
+            "Tape Player",
+            "Fuse 1",
+            "Fuse 2",
+            "Fuse 3",
+            "Override Key",
+            "Culture Sample"
+        ]
+    },
+    {
+        "name": "By Portable Generator",
+        "region": "Power Maze",
+        "original_item": "Green Herb",
+        "condition": {},
+        "item_object": "sm70_001",
+        "parent_object": "sm70_001",
+        "folder_path": "RopewayContents/World/Location_DownTown/LocationLevel_DownTown/LocationFsm_DownTown/S03_1000/ES_S03_1000/Item/ES_S03_1000/I_800_Substaion_Area/I_Deimos_Area",
+        "allow_item": [
+            "Battery Pack",
+            "Kendo Gate Key",
+            "Locker Room Key",
+            "Tape Player",
+            "Fuse 1",
+            "Fuse 2",
+            "Fuse 3",
+            "Override Key",
+            "Culture Sample"
+        ]
+    },
+    {
+        "name": "By Power Breaker",
+        "region": "Power Maze",
+        "original_item": "Green Herb",
+        "condition": {},
+        "item_object": "sm70_001",
+        "parent_object": "sm70_001",
+        "folder_path": "RopewayContents/World/Location_DownTown/LocationLevel_DownTown/LocationFsm_DownTown/S03_1000/ES_S03_1000/Item/ES_S03_1000/I_800_Substaion_Area/I_Deimos_Area",
+        "allow_item": [
+            "Battery Pack",
+            "Kendo Gate Key",
+            "Locker Room Key",
+            "Tape Player",
+            "Fuse 1",
+            "Fuse 2",
+            "Fuse 3",
+            "Override Key",
+            "Culture Sample"
+        ]
+    },
+    {
+        "name": "Breakable Box",
+        "region": "Power Maze",
+        "original_item": "Handgun Ammo",
+        "condition": {},
+        "item_object": "sm70_100",
+        "parent_object": "ItemPositions",
+        "folder_path": "RopewayContents/World/Location_DownTown/Environments/st03_0402_0/gimmick",
+        "allow_item": [
+            "Battery Pack",
+            "Kendo Gate Key",
+            "Locker Room Key",
+            "Tape Player",
+            "Fuse 1",
+            "Fuse 2",
+            "Fuse 3",
+            "Override Key",
+            "Culture Sample"
+        ]
+    },
+    {
+        "name": "Left Locker",
+        "region": "Substation",
+        "original_item": "Handgun Ammo",
         "condition": {
             "items": [
                 "Lock Pick"
             ]
         },
-        "item_object": "sm70_101",
-        "parent_object": "sm70_101_InCase",
-        "folder_path": "RopewayContents/World/Location_DownTown/LocationLevel_DownTown/LocationFsm_DownTown/S03_1000/ES_S03_1000/Item/ES_S03_1000/I_600_ControlStation_Area/I_PTCRoom"
+        "item_object": "sm70_100",
+        "parent_object": "sm70_100_KeyPickLocker",
+        "folder_path": "RopewayContents/World/Location_DownTown/LocationLevel_DownTown/LocationFsm_DownTown/S03_1000/ES_S03_1000/Item/ES_S03_1000/I_800_Substaion_Area/I_Building_Inside",
+        "allow_item": [
+            "Battery Pack",
+            "Kendo Gate Key",
+            "Locker Room Key",
+            "Tape Player",
+            "Fuse 1",
+            "Fuse 2",
+            "Fuse 3"
+        ]
+    },
+    {
+        "name": "1st Nemesis Case",
+        "region": "Nemesis Chase",
+        "original_item": "Supply Case - G19 Extended Mag",
+        "condition": {},
+        "item_object": "sm77_000",
+        "parent_object": "sm77_000",
+        "folder_path": "RopewayContents/World/Location_DownTown/LocationLevel_DownTown/LocationFsm_DownTown/S03_1000/ES_S03_1000/Item/ES_S03_1000/NemesisDropItems"
+    },
+    {
+        "name": "Locker",
+        "region": "Tool Shop",
+        "original_item": "First Aid Spray",
+        "condition": {
+            "items": [
+                "Lock Pick"
+            ]
+        },
+        "item_object": "sm70_000",
+        "parent_object": "sm70_000spray_keylockpos",
+        "folder_path": "RopewayContents/World/Location_DownTown/LocationLevel_DownTown/LocationFsm_DownTown/S03_1000/ES_S03_1000/Item/ES_S03_1000/I_700_Garage",
+        "allow_item": [
+            "Fire Hose",
+            "Battery Pack",
+            "Kendo Gate Key",
+            "Locker Room Key",
+            "Tape Player",
+            "Fuse 1",
+            "Fuse 2",
+            "Fuse 3",
+            "Override Key",
+            "Culture Sample"
+        ]
+    },
+    {
+        "name": "Locker",
+        "region": "Donut Shop",
+        "original_item": "Hand Grenade",
+        "condition": {
+            "items": [
+                "Lock Pick"
+            ]
+        },
+        "item_object": "WP6200",
+        "parent_object": "wp6200_grenade_In_LockedLocker",
+        "folder_path": "RopewayContents/World/Location_DownTown/LocationLevel_DownTown/LocationFsm_DownTown/S03_1000/ES_S03_1000/Item/ES_S03_1000/I_300_DounutShop_Area/_DounutShop_Inside",
+        "allow_item": [
+            "Fire Hose",
+            "Battery Pack",
+            "Kendo Gate Key",
+            "Locker Room Key",
+            "Tape Player",
+            "Fuse 1",
+            "Fuse 2",
+            "Fuse 3",
+            "Override Key",
+            "Culture Sample"
+        ]
     },
     {
         "name": "On Barrel",
@@ -440,18 +759,21 @@
         "folder_path": "RopewayContents/World/Location_DownTown/LocationLevel_DownTown/LocationFsm_DownTown/S03_1000/ES_S03_1000/Item/ES_S03_1000/I_600_ControlStation_Area/I_Street"
     },
     {
-        "name": "Tool Cabinet",
-        "region": "Tool Shop",
-        "original_item": "Bolt Cutters",
-        "condition": {},
-        "item_object": "sm73_001",
-        "parent_object": "sm73_001",
-        "folder_path": "RopewayContents/World/Location_DownTown/LocationLevel_DownTown/LocationFsm_DownTown/S03_1000/ES_S03_1000/Item/ES_S03_1000/KeyItem",
-        "randomized": 0
+        "name": "In Case Of Emergency",
+        "region": "Subway Office",
+        "original_item": "M3 Shotgun",
+        "condition": {
+            "items": [
+                "Bolt Cutters"
+            ]
+        },
+        "item_object": "WP1000",
+        "parent_object": "WP1000",
+        "folder_path": "RopewayContents/World/Location_DownTown/LocationLevel_DownTown/LocationFsm_DownTown/S03_1000/ES_S03_1000/Item/ES_S03_1000/Weapon"
     },
     {
-        "name": "Locker",
-        "region": "Tool Shop",
+        "name": "Left Locker",
+        "region": "Subway Office",
         "original_item": "First Aid Spray",
         "condition": {
             "items": [
@@ -459,211 +781,21 @@
             ]
         },
         "item_object": "sm70_000",
-        "parent_object": "sm70_000spray_keylockpos",
-        "folder_path": "RopewayContents/World/Location_DownTown/LocationLevel_DownTown/LocationFsm_DownTown/S03_1000/ES_S03_1000/Item/ES_S03_1000/I_700_Garage",
-        "allow_item": [
-            "Battery Pack",
-            "Kendo Gate Key",
-            "Locker Room Key",
-            "Tape Player",
-            "Fuse 1",
-            "Fuse 2",
-            "Fuse 3"
-        ]
+        "parent_object": "600_wp6200_grenade_01_In_LockedLocker",
+        "folder_path": "RopewayContents/World/Location_DownTown/LocationLevel_DownTown/LocationFsm_DownTown/S03_1000/ES_S03_1000/Item/ES_S03_1000/I_600_ControlStation_Area/I_ControlRoom"
     },
     {
-        "name": "On Table",
-        "region": "Garage",
+        "name": "Attache Case",
+        "region": "Subway Office",
         "original_item": "Shotgun Shells",
-        "condition": {},
-        "item_object": "sm70_101",
-        "parent_object": "sm70_101_sgshell",
-        "folder_path": "RopewayContents/World/Location_DownTown/LocationLevel_DownTown/LocationFsm_DownTown/S03_1000/ES_S03_1000/Item/ES_S03_1000/I_700_Garage",
-        "allow_item": [
-            "Battery Pack",
-            "Kendo Gate Key",
-            "Locker Room Key",
-            "Tape Player",
-            "Fuse 1",
-            "Fuse 2",
-            "Fuse 3"
-        ]
-    },
-    {
-        "name": "Downed UCBS Merc",
-        "region": "Back Alley",
-        "original_item": "Handgun Ammo",
-        "condition": {},
-        "item_object": "sm70_100",
-        "parent_object": "sm70_100",
-        "folder_path": "RopewayContents/World/Location_DownTown/LocationLevel_DownTown/LocationFsm_DownTown/S03_1000/ES_S03_1000/Item/ES_S03_1000/I_700_Garage"
-    },
-    {
-        "name": "Left Locker",
-        "region": "Substation",
-        "original_item": "Handgun Ammo",
         "condition": {
             "items": [
                 "Lock Pick"
             ]
         },
-        "item_object": "sm70_100",
-        "parent_object": "sm70_100_KeyPickLocker",
-        "folder_path": "RopewayContents/World/Location_DownTown/LocationLevel_DownTown/LocationFsm_DownTown/S03_1000/ES_S03_1000/Item/ES_S03_1000/I_800_Substaion_Area/I_Building_Inside",
-        "allow_item": [
-            "Battery Pack",
-            "Kendo Gate Key",
-            "Locker Room Key",
-            "Tape Player",
-            "Fuse 1",
-            "Fuse 2",
-            "Fuse 3"
-        ]
-    },
-    {
-        "name": "Right Locker",
-        "region": "Substation",
-        "original_item": "Gunpowder",
-        "condition": {},
-        "item_object": "sm70_205",
-        "parent_object": "sm70_205_gunp_Locker",
-        "folder_path": "RopewayContents/World/Location_DownTown/LocationLevel_DownTown/LocationFsm_DownTown/S03_1000/ES_S03_1000/Item/ES_S03_1000/I_800_Substaion_Area/I_Building_Inside",
-        "allow_item": [
-            "Battery Pack",
-            "Kendo Gate Key",
-            "Locker Room Key",
-            "Tape Player",
-            "Fuse 1",
-            "Fuse 2",
-            "Fuse 3"
-        ]
-    },
-    {
-        "name": "Table",
-        "region": "Substation",
-        "original_item": "Red Herb",
-        "condition": {},
-        "item_object": "sm70_002",
-        "parent_object": "sm70_002_rherb",
-        "folder_path": "RopewayContents/World/Location_DownTown/LocationLevel_DownTown/LocationFsm_DownTown/S03_1000/ES_S03_1000/Item/ES_S03_1000/I_800_Substaion_Area/I_Building_Inside",
-        "allow_item": [
-            "Battery Pack",
-            "Kendo Gate Key",
-            "Locker Room Key",
-            "Tape Player",
-            "Fuse 1",
-            "Fuse 2",
-            "Fuse 3"
-        ]
-    },
-    {
-        "name": "Control Room",
-        "region": "Substation",
-        "original_item": "Hip Pouch",
-        "condition": {},
-        "item_object": "sm74_200",
-        "parent_object": "sm74_200_SideBag",
-        "folder_path": "RopewayContents/World/Location_DownTown/LocationLevel_DownTown/LocationFsm_DownTown/S03_1000/ES_S03_1000/Item/ES_S03_1000/I_800_Substaion_Area/I_Building_Inside",
-        "allow_item": [
-            "Battery Pack",
-            "Kendo Gate Key",
-            "Locker Room Key",
-            "Tape Player",
-            "Fuse 1",
-            "Fuse 2",
-            "Fuse 3"
-        ]
-    },
-    {
-        "name": "Storage Racks 1",
-        "region": "Outdoor Area",
-        "original_item": "Green Herb",
-        "condition": {},
-        "item_object": "sm70_001",
-        "parent_object": "sm70_001",
-        "folder_path": "RopewayContents/World/Location_DownTown/LocationLevel_DownTown/LocationFsm_DownTown/S03_1000/ES_S03_1000/Item/ES_S03_1000/I_800_Substaion_Area/I_Deimos_Area/HerbPlanter",
-        "allow_item": [
-            "Battery Pack",
-            "Kendo Gate Key",
-            "Locker Room Key",
-            "Tape Player",
-            "Fuse 1",
-            "Fuse 2",
-            "Fuse 3"
-        ]
-    },
-    {
-        "name": "Storage Racks 2",
-        "region": "Outdoor Area",
-        "original_item": "Green Herb",
-        "condition": {},
-        "item_object": "sm70_001",
-        "parent_object": "sm70_001",
-        "folder_path": "RopewayContents/World/Location_DownTown/LocationLevel_DownTown/LocationFsm_DownTown/S03_1000/ES_S03_1000/Item/ES_S03_1000/I_800_Substaion_Area/I_Deimos_Area/HerbPlanter",
-        "allow_item": [
-            "Battery Pack",
-            "Kendo Gate Key",
-            "Locker Room Key",
-            "Tape Player",
-            "Fuse 1",
-            "Fuse 2",
-            "Fuse 3"
-        ]
-    },
-    {
-        "name": "Corpse",
-        "region": "Outdoor Area",
-        "original_item": "Lock Pick",
-        "condition": {},
-        "item_object": "EventPlay_EV322_k",
-        "parent_object": "",
-        "folder_path": "RopewayContents/World/Location_DownTown/LocationLevel_DownTown/Scenario/S03_1000/ES_S03_1000",
-        "randomized": 0
-    },
-    {
-        "name": "By Portable Generator",
-        "region": "Power Maze",
-        "original_item": "Green Herb",
-        "condition": {},
-        "item_object": "sm70_001",
-        "parent_object": "sm70_001",
-        "folder_path": "RopewayContents/World/Location_DownTown/LocationLevel_DownTown/LocationFsm_DownTown/S03_1000/ES_S03_1000/Item/ES_S03_1000/I_800_Substaion_Area/I_Deimos_Area",
-        "allow_item": [
-            "Battery Pack",
-            "Kendo Gate Key",
-            "Locker Room Key",
-            "Tape Player",
-            "Fuse 1",
-            "Fuse 2",
-            "Fuse 3"
-        ]
-    },
-    {
-        "name": "By Power Breaker",
-        "region": "Power Maze",
-        "original_item": "Green Herb",
-        "condition": {},
-        "item_object": "sm70_001",
-        "parent_object": "sm70_001",
-        "folder_path": "RopewayContents/World/Location_DownTown/LocationLevel_DownTown/LocationFsm_DownTown/S03_1000/ES_S03_1000/Item/ES_S03_1000/I_800_Substaion_Area/I_Deimos_Area",
-        "allow_item": [
-            "Battery Pack",
-            "Kendo Gate Key",
-            "Locker Room Key",
-            "Tape Player",
-            "Fuse 1",
-            "Fuse 2",
-            "Fuse 3"
-        ]
-    },
-    {
-        "name": "1st Nemesis Case",
-        "region": "Nemesis Chase",
-        "original_item": "Supply Case - G19 Extended Mag",
-        "condition": {},
-        "item_object": "sm77_000",
-        "parent_object": "sm77_000",
-        "folder_path": "RopewayContents/World/Location_DownTown/LocationLevel_DownTown/LocationFsm_DownTown/S03_1000/ES_S03_1000/Item/ES_S03_1000/NemesisDropItems"
+        "item_object": "sm70_101",
+        "parent_object": "sm70_101_InCase",
+        "folder_path": "RopewayContents/World/Location_DownTown/LocationLevel_DownTown/LocationFsm_DownTown/S03_1000/ES_S03_1000/Item/ES_S03_1000/I_600_ControlStation_Area/I_PTCRoom"
     },
     {
         "name": "2nd Nemesis Case",
@@ -673,6 +805,42 @@
         "item_object": "sm77_001",
         "parent_object": "sm77_001",
         "folder_path": "RopewayContents/World/Location_DownTown/LocationLevel_DownTown/LocationFsm_DownTown/S03_1000/ES_S03_1000/Item/ES_S03_1000/NemesisDropItems"
+    },
+    {
+        "name": "Counter",
+        "region": "Toy Shop",
+        "original_item": "Fancy Box - Green Jewel",
+        "condition": {},
+        "item_object": "sm73_311",
+        "parent_object": "sm73_311",
+        "folder_path": "RopewayContents/World/Location_DownTown/LocationLevel_DownTown/LocationFsm_DownTown/S03_1000/ES_S03_1000/Item/ES_S03_1000/KeyItem"
+    },
+    {
+        "name": "Counter By Door",
+        "region": "Supermarket",
+        "original_item": "Fancy Box - Blue Jewel",
+        "condition": {},
+        "item_object": "sm73_312",
+        "parent_object": "sm73_312",
+        "folder_path": "RopewayContents/World/Location_DownTown/LocationLevel_DownTown/LocationFsm_DownTown/S03_1000/ES_S03_1000/Item/ES_S03_1000/KeyItem"
+    },
+    {
+        "name": "North East Shelves",
+        "region": "Supermarket",
+        "original_item": "First Aid Spray",
+        "condition": {},
+        "item_object": "sm70_000",
+        "parent_object": "sm70_000",
+        "folder_path": "RopewayContents/World/Location_DownTown/LocationLevel_DownTown/LocationFsm_DownTown/S03_1000/ES_S03_1000/Item/ES_S03_1000/I_200_T-Junction_Area/I_205_SuperMarket"
+    },
+    {
+        "name": "Center Shelves",
+        "region": "Supermarket",
+        "original_item": "High-Grade Gunpowder",
+        "condition": {},
+        "item_object": "sm70_206",
+        "parent_object": "sm70_206",
+        "folder_path": "RopewayContents/World/Location_DownTown/LocationLevel_DownTown/LocationFsm_DownTown/S03_1000/ES_S03_1000/Item/ES_S03_1000/I_200_T-Junction_Area/I_205_SuperMarket"
     },
     {
         "name": "3rd Nemesis Case",
@@ -716,7 +884,9 @@
             "Tape Player",
             "Fuse 1",
             "Fuse 2",
-            "Fuse 3"
+            "Fuse 3",
+            "Override Key",
+            "Culture Sample"
         ]
     },
     {
@@ -734,7 +904,9 @@
             "Tape Player",
             "Fuse 1",
             "Fuse 2",
-            "Fuse 3"
+            "Fuse 3",
+            "Override Key",
+            "Culture Sample"
         ]
     },
     {
@@ -752,7 +924,9 @@
             "Tape Player",
             "Fuse 1",
             "Fuse 2",
-            "Fuse 3"
+            "Fuse 3",
+            "Override Key",
+            "Culture Sample"
         ]
     },
     {
@@ -770,7 +944,9 @@
             "Tape Player",
             "Fuse 1",
             "Fuse 2",
-            "Fuse 3"
+            "Fuse 3",
+            "Override Key",
+            "Culture Sample"
         ]
     },
     {
@@ -788,7 +964,9 @@
             "Tape Player",
             "Fuse 1",
             "Fuse 2",
-            "Fuse 3"
+            "Fuse 3",
+            "Override Key",
+            "Culture Sample"
         ]
     },
     {
@@ -806,7 +984,9 @@
             "Tape Player",
             "Fuse 1",
             "Fuse 2",
-            "Fuse 3"
+            "Fuse 3",
+            "Override Key",
+            "Culture Sample"
         ]
     },
     {
@@ -824,11 +1004,13 @@
             "Tape Player",
             "Fuse 1",
             "Fuse 2",
-            "Fuse 3"
+            "Fuse 3",
+            "Override Key",
+            "Culture Sample"
         ]
     },
     {
-        "name": "Floor by Lockers",
+        "name": "Floor By Lockers",
         "region": "Sewer Laboratory",
         "original_item": "Green Herb",
         "condition": {},
@@ -842,7 +1024,9 @@
             "Tape Player",
             "Fuse 1",
             "Fuse 2",
-            "Fuse 3"
+            "Fuse 3",
+            "Override Key",
+            "Culture Sample"
         ]
     },
     {
@@ -860,7 +1044,9 @@
             "Tape Player",
             "Fuse 1",
             "Fuse 2",
-            "Fuse 3"
+            "Fuse 3",
+            "Override Key",
+            "Culture Sample"
         ]
     },
     {
@@ -878,7 +1064,9 @@
             "Tape Player",
             "Fuse 1",
             "Fuse 2",
-            "Fuse 3"
+            "Fuse 3",
+            "Override Key",
+            "Culture Sample"
         ]
     },
     {
@@ -896,7 +1084,9 @@
             "Tape Player",
             "Fuse 1",
             "Fuse 2",
-            "Fuse 3"
+            "Fuse 3",
+            "Override Key",
+            "Culture Sample"
         ]
     },
     {
@@ -914,7 +1104,29 @@
             "Tape Player",
             "Fuse 1",
             "Fuse 2",
-            "Fuse 3"
+            "Fuse 3",
+            "Override Key",
+            "Culture Sample"
+        ]
+    },
+    {
+        "name": "Breakable Box",
+        "region": "Northwest Tunnel",
+        "original_item": "Explosive B",
+        "condition": {},
+        "item_object": "sm70_208",
+        "parent_object": "ItemPositions",
+        "folder_path": "RopewayContents/World/Location_DownTown/Environments/st03_0611_0/gimmick",
+        "allow_item": [
+            "Battery Pack",
+            "Kendo Gate Key",
+            "Locker Room Key",
+            "Tape Player",
+            "Fuse 1",
+            "Fuse 2",
+            "Fuse 3",
+            "Override Key",
+            "Culture Sample"
         ]
     },
     {
@@ -932,7 +1144,9 @@
             "Tape Player",
             "Fuse 1",
             "Fuse 2",
-            "Fuse 3"
+            "Fuse 3",
+            "Override Key",
+            "Culture Sample"
         ]
     },
     {
@@ -949,7 +1163,9 @@
             "Tape Player",
             "Fuse 1",
             "Fuse 2",
-            "Fuse 3"
+            "Fuse 3",
+            "Override Key",
+            "Culture Sample"
         ]
     },
     {
@@ -966,7 +1182,9 @@
             "Tape Player",
             "Fuse 1",
             "Fuse 2",
-            "Fuse 3"
+            "Fuse 3",
+            "Override Key",
+            "Culture Sample"
         ]
     },
     {
@@ -983,7 +1201,9 @@
             "Tape Player",
             "Fuse 1",
             "Fuse 2",
-            "Fuse 3"
+            "Fuse 3",
+            "Override Key",
+            "Culture Sample"
         ]
     },
     {
@@ -1000,11 +1220,13 @@
             "Tape Player",
             "Fuse 1",
             "Fuse 2",
-            "Fuse 3"
+            "Fuse 3",
+            "Override Key",
+            "Culture Sample"
         ]
     },
     {
-        "name": "Floor near Ladder",
+        "name": "Floor Near Ladder",
         "region": "Demolition Site Storage",
         "original_item": "Green Herb",
         "condition": {},
@@ -1017,7 +1239,9 @@
             "Tape Player",
             "Fuse 1",
             "Fuse 2",
-            "Fuse 3"
+            "Fuse 3",
+            "Override Key",
+            "Culture Sample"
         ]
     },
     {
@@ -1034,7 +1258,9 @@
             "Tape Player",
             "Fuse 1",
             "Fuse 2",
-            "Fuse 3"
+            "Fuse 3",
+            "Override Key",
+            "Culture Sample"
         ]
     },
     {
@@ -1051,7 +1277,9 @@
             "Tape Player",
             "Fuse 1",
             "Fuse 2",
-            "Fuse 3"
+            "Fuse 3",
+            "Override Key",
+            "Culture Sample"
         ]
     },
     {
@@ -1068,7 +1296,9 @@
             "Tape Player",
             "Fuse 1",
             "Fuse 2",
-            "Fuse 3"
+            "Fuse 3",
+            "Override Key",
+            "Culture Sample"
         ]
     },
     {
@@ -1085,11 +1315,13 @@
             "Tape Player",
             "Fuse 1",
             "Fuse 2",
-            "Fuse 3"
+            "Fuse 3",
+            "Override Key",
+            "Culture Sample"
         ]
     },
     {
-        "name": "Box by Portable Generator 1",
+        "name": "Box By Portable Generator 1",
         "region": "Demolition Site Roof",
         "original_item": "Explosive Rounds",
         "condition": {},
@@ -1102,11 +1334,13 @@
             "Tape Player",
             "Fuse 1",
             "Fuse 2",
-            "Fuse 3"
+            "Fuse 3",
+            "Override Key",
+            "Culture Sample"
         ]
     },
     {
-        "name": "Box by Portable Generator 2",
+        "name": "Box By Portable Generator 2",
         "region": "Demolition Site Roof",
         "original_item": "Handgun Ammo",
         "condition": {},
@@ -1119,7 +1353,9 @@
             "Tape Player",
             "Fuse 1",
             "Fuse 2",
-            "Fuse 3"
+            "Fuse 3",
+            "Override Key",
+            "Culture Sample"
         ]
     },
     {
@@ -1136,7 +1372,9 @@
             "Tape Player",
             "Fuse 1",
             "Fuse 2",
-            "Fuse 3"
+            "Fuse 3",
+            "Override Key",
+            "Culture Sample"
         ]
     },
     {
@@ -1149,7 +1387,7 @@
         "folder_path": "RopewayContents/World/Location_DownTown/LocationLevel_DownTown/LocationFsm_DownTown/S03_1000/ES_S03_1000/Item/ES_S03_1000/I_1100_Kendo_Area/I_RPD_Street"
     },
     {
-        "name": "Case near RPD Garage",
+        "name": "Case Near RPD Garage",
         "region": "Outside Gun Shop",
         "original_item": "Handgun Ammo",
         "condition": {},
@@ -1162,7 +1400,9 @@
             "Tape Player",
             "Fuse 1",
             "Fuse 2",
-            "Fuse 3"
+            "Fuse 3",
+            "Override Key",
+            "Culture Sample"
         ]
     },
     {
@@ -1179,7 +1419,9 @@
             "Tape Player",
             "Fuse 1",
             "Fuse 2",
-            "Fuse 3"
+            "Fuse 3",
+            "Override Key",
+            "Culture Sample"
         ]
     },
     {
@@ -1196,7 +1438,9 @@
             "Tape Player",
             "Fuse 1",
             "Fuse 2",
-            "Fuse 3"
+            "Fuse 3",
+            "Override Key",
+            "Culture Sample"
         ]
     },
     {
@@ -1213,7 +1457,9 @@
             "Tape Player",
             "Fuse 1",
             "Fuse 2",
-            "Fuse 3"
+            "Fuse 3",
+            "Override Key",
+            "Culture Sample"
         ]
     },
     {
@@ -1230,7 +1476,9 @@
             "Tape Player",
             "Fuse 1",
             "Fuse 2",
-            "Fuse 3"
+            "Fuse 3",
+            "Override Key",
+            "Culture Sample"
         ]
     },
     {
@@ -1247,7 +1495,9 @@
             "Tape Player",
             "Fuse 1",
             "Fuse 2",
-            "Fuse 3"
+            "Fuse 3",
+            "Override Key",
+            "Culture Sample"
         ]
     },
     {
@@ -1264,7 +1514,9 @@
             "Tape Player",
             "Fuse 1",
             "Fuse 2",
-            "Fuse 3"
+            "Fuse 3",
+            "Override Key",
+            "Culture Sample"
         ]
     },
     {
@@ -1281,7 +1533,9 @@
             "Tape Player",
             "Fuse 1",
             "Fuse 2",
-            "Fuse 3"
+            "Fuse 3",
+            "Override Key",
+            "Culture Sample"
         ]
     },
     {
@@ -1297,7 +1551,9 @@
             "Tape Player",
             "Fuse 1",
             "Fuse 2",
-            "Fuse 3"
+            "Fuse 3",
+            "Override Key",
+            "Culture Sample"
         ]
     },
     {
@@ -1317,8 +1573,19 @@
             "Tape Player",
             "Fuse 1",
             "Fuse 2",
-            "Fuse 3"
+            "Fuse 3",
+            "Override Key",
+            "Culture Sample"
         ]
+    },
+    {
+        "name": "Breakable Box",
+        "region": "Scaffolding",
+        "original_item": "First Aid Spray",
+        "condition": {},
+        "item_object": "sm70_000",
+        "parent_object": "ItemPositions",
+        "folder_path": "RopewayContents/World/Location_DownTown/Environments/st03_0228_0/gimmick"
     },
     {
         "name": "4th Nemesis Case",
@@ -1336,6 +1603,15 @@
         "item_object": "sm77_004",
         "parent_object": "sm77_004",
         "folder_path": "RopewayContents/World/Location_DownTown/LocationLevel_DownTown/LocationFsm_DownTown/S03_1000/ES_S03_1000/Item/ES_S03_1000/NemesisDropItems"
+    },
+    {
+        "name": "Breakable Box",
+        "region": "East Courtyard",
+        "original_item": "Assault Rifle Ammo",
+        "condition": {},
+        "item_object": "sm70_102",
+        "parent_object": "ItemPositions",
+        "folder_path": "RopewayContents/World/Location_RPD/Environments/st02_0301_0/gimmick_Escape"
     },
     {
         "name": "Near Breakable Box",
@@ -1356,7 +1632,7 @@
         "folder_path": "RopewayManagers/TemporaryObjects/Enemy"
     },
     {
-        "name": "Crates near Medallion Statue",
+        "name": "Crates Near Medallion Statue",
         "region": "Main Lobby",
         "original_item": "Green Herb",
         "condition": {},
@@ -1368,7 +1644,9 @@
             "Tape Player",
             "Fuse 1",
             "Fuse 2",
-            "Fuse 3"
+            "Fuse 3",
+            "Override Key",
+            "Culture Sample"
         ]
     },
     {
@@ -1384,7 +1662,9 @@
             "Tape Player",
             "Fuse 1",
             "Fuse 2",
-            "Fuse 3"
+            "Fuse 3",
+            "Override Key",
+            "Culture Sample"
         ]
     },
     {
@@ -1413,7 +1693,9 @@
             "Tape Player",
             "Fuse 1",
             "Fuse 2",
-            "Fuse 3"
+            "Fuse 3",
+            "Override Key",
+            "Culture Sample"
         ]
     },
     {
@@ -1429,7 +1711,27 @@
             "Tape Player",
             "Fuse 1",
             "Fuse 2",
-            "Fuse 3"
+            "Fuse 3",
+            "Override Key",
+            "Culture Sample"
+        ]
+    },
+    {
+        "name": "Breakable Box",
+        "region": "West Hallway 1F",
+        "original_item": "Handgun Ammo",
+        "condition": {},
+        "item_object": "sm70_100",
+        "parent_object": "ItemPositions",
+        "folder_path": "RopewayContents/World/Location_RPD/Environments/st02_0217_0/gimmick_Escape",
+        "allow_item": [
+            "Locker Room Key",
+            "Tape Player",
+            "Fuse 1",
+            "Fuse 2",
+            "Fuse 3",
+            "Override Key",
+            "Culture Sample"
         ]
     },
     {
@@ -1458,11 +1760,13 @@
             "Tape Player",
             "Fuse 1",
             "Fuse 2",
-            "Fuse 3"
+            "Fuse 3",
+            "Override Key",
+            "Culture Sample"
         ]
     },
     {
-        "name": "Desk near Safe",
+        "name": "Desk Near Safe",
         "region": "West Office",
         "original_item": "Handgun Ammo",
         "condition": {},
@@ -1474,7 +1778,9 @@
             "Tape Player",
             "Fuse 1",
             "Fuse 2",
-            "Fuse 3"
+            "Fuse 3",
+            "Override Key",
+            "Culture Sample"
         ]
     },
     {
@@ -1490,11 +1796,13 @@
             "Tape Player",
             "Fuse 1",
             "Fuse 2",
-            "Fuse 3"
+            "Fuse 3",
+            "Override Key",
+            "Culture Sample"
         ]
     },
     {
-        "name": "Cabinet near Reception Window",
+        "name": "Cabinet Near Reception Window",
         "region": "West Office",
         "original_item": "Red Herb",
         "condition": {},
@@ -1506,7 +1814,9 @@
             "Tape Player",
             "Fuse 1",
             "Fuse 2",
-            "Fuse 3"
+            "Fuse 3",
+            "Override Key",
+            "Culture Sample"
         ]
     },
     {
@@ -1522,7 +1832,9 @@
             "Tape Player",
             "Fuse 1",
             "Fuse 2",
-            "Fuse 3"
+            "Fuse 3",
+            "Override Key",
+            "Culture Sample"
         ]
     },
     {
@@ -1538,7 +1850,9 @@
             "Tape Player",
             "Fuse 1",
             "Fuse 2",
-            "Fuse 3"
+            "Fuse 3",
+            "Override Key",
+            "Culture Sample"
         ]
     },
     {
@@ -1558,6 +1872,24 @@
         ]
     },
     {
+        "name": "Breakable Box",
+        "region": "West Hallway 3F",
+        "original_item": "Red Herb",
+        "condition": {},
+        "item_object": "sm70_002",
+        "parent_object": "ItemPositions",
+        "folder_path": "RopewayContents/World/Location_RPD/Environments/st02_0603_0/gimmick_Escape",
+        "allow_item": [
+            "Locker Room Key",
+            "Tape Player",
+            "Fuse 1",
+            "Fuse 2",
+            "Fuse 3",
+            "Override Key",
+            "Culture Sample"
+        ]
+    },
+    {
         "name": "DCM Locker",
         "region": "West Hallway 3F",
         "original_item": "Assault Rifle Ammo",
@@ -1570,7 +1902,9 @@
             "Tape Player",
             "Fuse 1",
             "Fuse 2",
-            "Fuse 3"
+            "Fuse 3",
+            "Override Key",
+            "Culture Sample"
         ]
     },
     {
@@ -1606,7 +1940,9 @@
             "Tape Player",
             "Fuse 1",
             "Fuse 2",
-            "Fuse 3"
+            "Fuse 3",
+            "Override Key",
+            "Culture Sample"
         ]
     },
     {
@@ -1632,7 +1968,9 @@
             "Tape Player",
             "Fuse 1",
             "Fuse 2",
-            "Fuse 3"
+            "Fuse 3",
+            "Override Key",
+            "Culture Sample"
         ]
     },
     {
@@ -1648,7 +1986,9 @@
             "Tape Player",
             "Fuse 1",
             "Fuse 2",
-            "Fuse 3"
+            "Fuse 3",
+            "Override Key",
+            "Culture Sample"
         ]
     },
     {
@@ -1664,7 +2004,9 @@
             "Tape Player",
             "Fuse 1",
             "Fuse 2",
-            "Fuse 3"
+            "Fuse 3",
+            "Override Key",
+            "Culture Sample"
         ]
     },
     {
@@ -1727,7 +2069,7 @@
         "folder_path": "RopewayContents/World/Location_RPD/Environments/st02_0404_0/gimmick_Escape"
     },
     {
-        "name": "Desk by Armory",
+        "name": "Desk By Armory",
         "region": "STARS Office",
         "original_item": "Flash Grenade",
         "condition": {},
@@ -1745,7 +2087,7 @@
         "folder_path": "RopewayContents/World/Location_RPD/LocationLevel_RPD/Item/common/ES_common"
     },
     {
-        "name": "Box by Entrance",
+        "name": "Box By Entrance",
         "region": "STARS Office",
         "original_item": "Red Herb",
         "condition": {},
@@ -1766,7 +2108,9 @@
             "Tape Player",
             "Fuse 1",
             "Fuse 2",
-            "Fuse 3"
+            "Fuse 3",
+            "Override Key",
+            "Culture Sample"
         ]
     },
     {
@@ -1782,7 +2126,9 @@
             "Tape Player",
             "Fuse 1",
             "Fuse 2",
-            "Fuse 3"
+            "Fuse 3",
+            "Override Key",
+            "Culture Sample"
         ]
     },
     {
@@ -1798,7 +2144,9 @@
             "Tape Player",
             "Fuse 1",
             "Fuse 2",
-            "Fuse 3"
+            "Fuse 3",
+            "Override Key",
+            "Culture Sample"
         ]
     },
     {
@@ -1814,7 +2162,9 @@
             "Tape Player",
             "Fuse 1",
             "Fuse 2",
-            "Fuse 3"
+            "Fuse 3",
+            "Override Key",
+            "Culture Sample"
         ]
     },
     {
@@ -1830,11 +2180,13 @@
             "Tape Player",
             "Fuse 1",
             "Fuse 2",
-            "Fuse 3"
+            "Fuse 3",
+            "Override Key",
+            "Culture Sample"
         ]
     },
     {
-        "name": "Bench by Waterside",
+        "name": "Bench By Waterside",
         "region": "Promenade",
         "original_item": "Handgun Ammo",
         "condition": {},
@@ -1843,13 +2195,40 @@
         "folder_path": "RopewayContents/World/Location_ClockTower/LocationLevel_ClockTower/Item"
     },
     {
-        "name": "Bench near Statues",
+        "name": "Bench Near Statues",
         "region": "Promenade",
         "original_item": "Green Herb",
         "condition": {},
         "item_object": "sm70_001",
         "parent_object": "sm70_001gherb",
         "folder_path": "RopewayContents/World/Location_ClockTower/LocationLevel_ClockTower/Item"
+    },
+    {
+        "name": "Breakable Box",
+        "region": "Promenade",
+        "original_item": "Red Herb",
+        "condition": {},
+        "item_object": "sm70_002",
+        "parent_object": "ItemPositions",
+        "folder_path": "RopewayContents/World/Location_ClockTower/Environments/st03_0804_0/gimmick"
+    },
+    {
+        "name": "Breakable Box By School Bus",
+        "region": "Plaza",
+        "original_item": "Red Herb",
+        "condition": {},
+        "item_object": "sm70_002",
+        "parent_object": "ItemPositions",
+        "folder_path": "RopewayContents/World/Location_ClockTower/Environments/st03_0806_0/gimmick"
+    },
+    {
+        "name": "Breakable Box By City Bus",
+        "region": "Plaza",
+        "original_item": "Green Herb",
+        "condition": {},
+        "item_object": "sm70_001",
+        "parent_object": "ItemPositions",
+        "folder_path": "RopewayContents/World/Location_ClockTower/Environments/st03_0806_0/gimmick"
     },
     {
         "name": "By School Bus 1",
@@ -1897,7 +2276,7 @@
         "folder_path": "RopewayContents/World/Location_ClockTower/Environments/st03_0806_0/gimmick"
     },
     {
-        "name": "By Bus 1",
+        "name": "By City Bus 1",
         "region": "Plaza",
         "original_item": "Shotgun Shells",
         "condition": {},
@@ -1906,7 +2285,7 @@
         "folder_path": "RopewayContents/World/Location_ClockTower/LocationLevel_ClockTower/Item"
     },
     {
-        "name": "By Bus 2",
+        "name": "By City Bus 2",
         "region": "Plaza",
         "original_item": "Handgun Ammo",
         "condition": {},
@@ -1976,6 +2355,15 @@
         "item_object": "sm70_001",
         "parent_object": "st04_0105_sm70_001_00",
         "folder_path": "RopewayContents/World/Location_Hospital/LocationLevel_Hospital/Item/common/st04_0105"
+    },
+    {
+        "name": "Breakable Box Near Operating Room",
+        "region": "Emergency Entrance",
+        "original_item": "Handgun Ammo",
+        "condition": {},
+        "item_object": "sm70_100",
+        "parent_object": "ItemPositions",
+        "folder_path": "RopewayContents/World/Location_Hospital/Environments/st04_0107_0/gimmick"
     },
     {
         "name": "Table",
@@ -2113,7 +2501,7 @@
         "folder_path": "RopewayContents/World/Location_Hospital/LocationLevel_Hospital/Item/common/ES_common/Item/st04_0104"
     },
     {
-        "name": "Far Locker",
+        "name": "West Locker",
         "region": "Locker Room",
         "original_item": "Hospital ID Card",
         "condition": {},
@@ -2123,7 +2511,7 @@
         "randomized": 0
     },
     {
-        "name": "Left Locker",
+        "name": "North Locker",
         "region": "Locker Room",
         "original_item": "Flash Grenade",
         "condition": {},
@@ -2239,7 +2627,16 @@
         "item_object": "sm70_001",
         "parent_object": "st04_0108_sm70_001_00",
         "folder_path": "RopewayContents/World/Location_Hospital/LocationLevel_Hospital/Item/common/st04_0108"
-    },    
+    },
+    {
+        "name": "Breakable Box Near Locker",
+        "region": "Emergency Entrance",
+        "original_item": "Assault Rifle Ammo",
+        "condition": {},
+        "item_object": "sm70_102",
+        "parent_object": "ItemPositions",
+        "folder_path": "RopewayContents/World/Location_Hospital/Environments/st04_0107_0/gimmick"
+    },
     {
         "name": "Desk 1",
         "region": "Research Laboratory",
@@ -2325,7 +2722,9 @@
         "allow_item": [
             "Fuse 1",
             "Fuse 2",
-            "Fuse 3"
+            "Fuse 3",
+            "Override Key",
+            "Culture Sample"
         ]
     },
     {
@@ -2348,6 +2747,48 @@
         ]
     },
     {
+        "name": "Breakable Box Near Sickroom",
+        "region": "Hospital Lobby",
+        "original_item": "Handgun Ammo",
+        "condition": {
+            "items": [
+                "Lock Pick",
+                "Vaccine Sample"
+            ]
+        },
+        "item_object": "sm70_100",
+        "parent_object": "ItemPositions",
+        "folder_path": "RopewayContents/World/Location_Hospital/Environments/st04_0102_0/gimmick_Hospital2",
+        "allow_item": [
+            "Fuse 1",
+            "Fuse 2",
+            "Fuse 3",
+            "Override Key",
+            "Culture Sample"
+        ]
+    },
+    {
+        "name": "Breakable Box Near Reception",
+        "region": "Hospital Lobby",
+        "original_item": "Handgun Ammo",
+        "condition": {
+            "items": [
+                "Lock Pick",
+                "Vaccine Sample"
+            ]
+        },
+        "item_object": "sm70_100",
+        "parent_object": "ItemPositions",
+        "folder_path": "RopewayContents/World/Location_Hospital/Environments/st04_0102_0/gimmick_Hospital2",
+        "allow_item": [
+            "Fuse 1",
+            "Fuse 2",
+            "Fuse 3",
+            "Override Key",
+            "Culture Sample"
+        ]
+    },
+    {
         "name": "Attache Case",
         "region": "Main Corridor",
         "original_item": "MAG Ammo",
@@ -2363,7 +2804,9 @@
         "allow_item": [
             "Fuse 1",
             "Fuse 2",
-            "Fuse 3"
+            "Fuse 3",
+            "Override Key",
+            "Culture Sample"
         ]
     },
     {
@@ -2382,7 +2825,9 @@
         "allow_item": [
             "Fuse 1",
             "Fuse 2",
-            "Fuse 3"
+            "Fuse 3",
+            "Override Key",
+            "Culture Sample"
         ]
     },
     {
@@ -2401,7 +2846,9 @@
         "allow_item": [
             "Fuse 1",
             "Fuse 2",
-            "Fuse 3"
+            "Fuse 3",
+            "Override Key",
+            "Culture Sample"
         ]
     },
     {
@@ -2420,7 +2867,9 @@
         "allow_item": [
             "Fuse 1",
             "Fuse 2",
-            "Fuse 3"
+            "Fuse 3",
+            "Override Key",
+            "Culture Sample"
         ]
     },
     {
@@ -2439,7 +2888,9 @@
         "allow_item": [
             "Fuse 1",
             "Fuse 2",
-            "Fuse 3"
+            "Fuse 3",
+            "Override Key",
+            "Culture Sample"
         ]
     },
     {
@@ -2458,7 +2909,9 @@
         "allow_item": [
             "Fuse 1",
             "Fuse 2",
-            "Fuse 3"
+            "Fuse 3",
+            "Override Key",
+            "Culture Sample"
         ]
     },
     {
@@ -2477,7 +2930,9 @@
         "allow_item": [
             "Fuse 1",
             "Fuse 2",
-            "Fuse 3"
+            "Fuse 3",
+            "Override Key",
+            "Culture Sample"
         ]
     },
     {
@@ -2496,7 +2951,25 @@
         "allow_item": [
             "Fuse 1",
             "Fuse 2",
-            "Fuse 3"
+            "Fuse 3",
+            "Override Key",
+            "Culture Sample"
+        ]
+    },
+    {
+        "name": "Breakable Box",
+        "region": "Generator Room",
+        "original_item": "Handgun Ammo",
+        "condition": {},
+        "item_object": "sm70_100",
+        "parent_object": "ItemPositions",
+        "folder_path": "RopewayContents/World/Location_Hospital2/Environments/st04_0301_1/gimmick",
+        "allow_item": [
+            "Fuse 1",
+            "Fuse 2",
+            "Fuse 3",
+            "Override Key",
+            "Culture Sample"
         ]
     },
     {
@@ -2510,7 +2983,9 @@
         "allow_item": [
             "Fuse 1",
             "Fuse 2",
-            "Fuse 3"
+            "Fuse 3",
+            "Override Key",
+            "Culture Sample"
         ]
     },
     {
@@ -2524,7 +2999,9 @@
         "allow_item": [
             "Fuse 1",
             "Fuse 2",
-            "Fuse 3"
+            "Fuse 3",
+            "Override Key",
+            "Culture Sample"
         ]
     },
     {
@@ -2538,7 +3015,9 @@
         "allow_item": [
             "Fuse 1",
             "Fuse 2",
-            "Fuse 3"
+            "Fuse 3",
+            "Override Key",
+            "Culture Sample"
         ]
     },
     {
@@ -2552,7 +3031,41 @@
         "allow_item": [
             "Fuse 1",
             "Fuse 2",
-            "Fuse 3"
+            "Fuse 3",
+            "Override Key",
+            "Culture Sample"
+        ]
+    },
+    {
+        "name": "Breakable Box 1",
+        "region": "Warehouse",
+        "original_item": "Handgun Ammo",
+        "condition": {},
+        "item_object": "sm70_100",
+        "parent_object": "ItemPositions",
+        "folder_path": "RopewayContents/World/Location_Hospital2/Environments/st04_0403_1/gimmick",
+        "allow_item": [
+            "Fuse 1",
+            "Fuse 2",
+            "Fuse 3",
+            "Override Key",
+            "Culture Sample"
+        ]
+    },
+    {
+        "name": "Breakable Box 2",
+        "region": "Warehouse",
+        "original_item": "Handgun Ammo",
+        "condition": {},
+        "item_object": "sm70_100",
+        "parent_object": "ItemPositions",
+        "folder_path": "RopewayContents/World/Location_Hospital2/Environments/st04_0403_1/gimmick",
+        "allow_item": [
+            "Fuse 1",
+            "Fuse 2",
+            "Fuse 3",
+            "Override Key",
+            "Culture Sample"
         ]
     },
     {
@@ -2566,7 +3079,9 @@
         "allow_item": [
             "Fuse 1",
             "Fuse 2",
-            "Fuse 3"
+            "Fuse 3",
+            "Override Key",
+            "Culture Sample"
         ]
     },
     {
@@ -2580,11 +3095,13 @@
         "allow_item": [
             "Fuse 1",
             "Fuse 2",
-            "Fuse 3"
+            "Fuse 3",
+            "Override Key",
+            "Culture Sample"
         ]
     },
     {
-        "name": "Case by Lift",
+        "name": "Case By Lift",
         "region": "Warehouse",
         "original_item": "Shell Holder - M3",
         "condition": {},
@@ -2594,7 +3111,9 @@
         "allow_item": [
             "Fuse 1",
             "Fuse 2",
-            "Fuse 3"
+            "Fuse 3",
+            "Override Key",
+            "Culture Sample"
         ]
     },
     {
@@ -2608,7 +3127,9 @@
         "allow_item": [
             "Fuse 1",
             "Fuse 2",
-            "Fuse 3"
+            "Fuse 3",
+            "Override Key",
+            "Culture Sample"
         ]
     },
     {
@@ -2622,11 +3143,13 @@
         "allow_item": [
             "Fuse 1",
             "Fuse 2",
-            "Fuse 3"
+            "Fuse 3",
+            "Override Key",
+            "Culture Sample"
         ]
     },
     {
-        "name": "In Container by Fuse 1",
+        "name": "In Container By Fuse 1",
         "region": "Warehouse",
         "original_item": "Gunpowder",
         "condition": {},
@@ -2636,11 +3159,13 @@
         "allow_item": [
             "Fuse 1",
             "Fuse 2",
-            "Fuse 3"
+            "Fuse 3",
+            "Override Key",
+            "Culture Sample"
         ]
     },
     {
-        "name": "In Container by Fuse 2",
+        "name": "In Container By Fuse 2",
         "region": "Warehouse",
         "original_item": "Gunpowder",
         "condition": {},
@@ -2650,11 +3175,13 @@
         "allow_item": [
             "Fuse 1",
             "Fuse 2",
-            "Fuse 3"
+            "Fuse 3",
+            "Override Key",
+            "Culture Sample"
         ]
     },
     {
-        "name": "In Container by Fuse 3",
+        "name": "In Container By Fuse 3",
         "region": "Warehouse",
         "original_item": "High-Grade Gunpowder",
         "condition": {},
@@ -2664,11 +3191,13 @@
         "allow_item": [
             "Fuse 1",
             "Fuse 2",
-            "Fuse 3"
+            "Fuse 3",
+            "Override Key",
+            "Culture Sample"
         ]
     },
     {
-        "name": "In Container by Fuse 4",
+        "name": "In Container By Fuse 4",
         "region": "Warehouse",
         "original_item": "Green Herb",
         "condition": {},
@@ -2678,11 +3207,13 @@
         "allow_item": [
             "Fuse 1",
             "Fuse 2",
-            "Fuse 3"
+            "Fuse 3",
+            "Override Key",
+            "Culture Sample"
         ]
     },
     {
-        "name": "Box near Fuse",
+        "name": "Box Near Fuse",
         "region": "Warehouse",
         "original_item": "Gunpowder",
         "condition": {},
@@ -2692,7 +3223,9 @@
         "allow_item": [
             "Fuse 1",
             "Fuse 2",
-            "Fuse 3"
+            "Fuse 3",
+            "Override Key",
+            "Culture Sample"
         ]
     },
     {
@@ -2706,7 +3239,9 @@
         "allow_item": [
             "Fuse 1",
             "Fuse 2",
-            "Fuse 3"
+            "Fuse 3",
+            "Override Key",
+            "Culture Sample"
         ]
     },
     {
@@ -2720,7 +3255,9 @@
         "allow_item": [
             "Fuse 1",
             "Fuse 2",
-            "Fuse 3"
+            "Fuse 3",
+            "Override Key",
+            "Culture Sample"
         ]
     },
     {
@@ -2734,7 +3271,9 @@
         "allow_item": [
             "Fuse 1",
             "Fuse 2",
-            "Fuse 3"
+            "Fuse 3",
+            "Override Key",
+            "Culture Sample"
         ]
     },
     {
@@ -2748,7 +3287,9 @@
         "allow_item": [
             "Fuse 1",
             "Fuse 2",
-            "Fuse 3"
+            "Fuse 3",
+            "Override Key",
+            "Culture Sample"
         ]
     },
     {
@@ -2758,7 +3299,11 @@
         "condition": {},
         "item_object": "sm71_300",
         "parent_object": "st04_0405_sm71_300_00",
-        "folder_path": "RopewayContents/World/Location_Hospital2/LocationLevel_Hospital2/Item/common/ES_common/st04_0405"
+        "folder_path": "RopewayContents/World/Location_Hospital2/LocationLevel_Hospital2/Item/common/ES_common/st04_0405",
+        "allow_item": [
+            "Override Key",
+            "Culture Sample"
+        ]
     },
     {
         "name": "Shelves",
@@ -2767,34 +3312,59 @@
         "condition": {},
         "item_object": "sm70_206",
         "parent_object": "sm70_206",
-        "folder_path": "RopewayContents/World/Location_Laboratory/LocationLevel_Laboratory/Item/common/ES_Common/01_LockerRoom"
+        "folder_path": "RopewayContents/World/Location_Laboratory/LocationLevel_Laboratory/Item/common/ES_Common/01_LockerRoom",
+        "allow_item": [
+            "Override Key",
+            "Culture Sample"
+        ]
     },
     {
-        "name": "Near Computers",
+        "name": "Near Computers 1",
         "region": "Laboratory Storage",
         "original_item": "MGL Grenade Launcher",
         "condition": {},
         "item_object": "WP4100",
         "parent_object": "WP4100",
-        "folder_path": "RopewayContents/World/Location_Laboratory/LocationLevel_Laboratory/Item/common/ES_Common/99_ReliefWeapon"
+        "folder_path": "RopewayContents/World/Location_Laboratory/LocationLevel_Laboratory/Item/common/ES_Common/99_ReliefWeapon",
+        "allow_item": [
+            "Override Key",
+            "Culture Sample"
+        ]
     },
     {
-        "name": "Near Item Box",
+        "name": "Near Computers 2",
         "region": "Laboratory Storage",
         "original_item": "M3 Shotgun",
         "condition": {},
         "item_object": "WP1000",
         "parent_object": "WP1000",
-        "folder_path": "RopewayContents/World/Location_Laboratory/LocationLevel_Laboratory/Item/common/ES_Common/99_ReliefWeapon"
+        "folder_path": "RopewayContents/World/Location_Laboratory/LocationLevel_Laboratory/Item/common/ES_Common/99_ReliefWeapon",
+        "allow_item": [
+            "Override Key",
+            "Culture Sample"
+        ]
     },
     {
-        "name": "Floor by Door",
+        "name": "Floor By Door",
         "region": "Laboratory Storage",
         "original_item": "Green Herb",
         "condition": {},
         "item_object": "sm70_001",
         "parent_object": "sm70_001",
-        "folder_path": "RopewayContents/World/Location_Laboratory/LocationLevel_Laboratory/Item/common/ES_Common/01_LockerRoom"
+        "folder_path": "RopewayContents/World/Location_Laboratory/LocationLevel_Laboratory/Item/common/ES_Common/01_LockerRoom",
+        "allow_item": [
+            "Override Key",
+            "Culture Sample"
+        ]
+    },
+    {
+        "name": "Breakable Box",
+        "region": "Laboratory Hallway 2F",
+        "original_item": "High-Grade Gunpowder",
+        "condition": {},
+        "item_object": "sm70_100",
+        "parent_object": "ItemPositions",
+        "folder_path": "RopewayContents/World/Location_Laboratory/Environments/st05_0104_0/gimmick"
     },
     {
         "name": "Shelves",
@@ -2803,7 +3373,11 @@
         "condition": {},
         "item_object": "sm70_206",
         "parent_object": "sm70_206",
-        "folder_path": "RopewayContents/World/Location_Laboratory/LocationLevel_Laboratory/Item/common/ES_Common/02_Laboratory"
+        "folder_path": "RopewayContents/World/Location_Laboratory/LocationLevel_Laboratory/Item/common/ES_Common/02_Laboratory",
+        "allow_item": [
+            "Override Key",
+            "Culture Sample"
+        ]
     },
     {
         "name": "By Corpse",
@@ -2812,7 +3386,11 @@
         "condition": {},
         "item_object": "sm70_100",
         "parent_object": "sm70_100",
-        "folder_path": "RopewayContents/World/Location_Laboratory/LocationLevel_Laboratory/Item/common/ES_Common/02_Laboratory"
+        "folder_path": "RopewayContents/World/Location_Laboratory/LocationLevel_Laboratory/Item/common/ES_Common/02_Laboratory",
+        "allow_item": [
+            "Override Key",
+            "Culture Sample"
+        ]
     },
     {
         "name": "In Terminal",
@@ -2822,7 +3400,10 @@
         "item_object": "sm42_503_ES_LabMonitor04A_00_gimmick",
         "parent_object": "",
         "folder_path": "RopewayContents/World/Location_Laboratory/Environments/st05_0108_0/gimmick",
-        "randomized": 0
+        "allow_item": [
+            "Override Key",
+            "Culture Sample"
+        ]
     },
     {
         "name": "Storage",
@@ -2832,7 +3413,9 @@
         "item_object": "st05_0107_sm41_426_ES_GrowthMachine01A_gimmick",
         "parent_object": "",
         "folder_path": "RopewayContents/World/Location_Laboratory/Environments/st05_0107_0/gimmick",
-        "randomized": 0
+        "allow_item": [
+            "Culture Sample"
+        ]
     },
     {
         "name": "On Cart 1",
@@ -2841,7 +3424,10 @@
         "condition": {},
         "item_object": "sm70_205",
         "parent_object": "sm70_205",
-        "folder_path": "RopewayContents/World/Location_Laboratory/LocationLevel_Laboratory/Item/common/ES_Common/02_Laboratory"
+        "folder_path": "RopewayContents/World/Location_Laboratory/LocationLevel_Laboratory/Item/common/ES_Common/02_Laboratory",
+        "allow_item": [
+            "Culture Sample"
+        ]
     },
     {
         "name": "On Cart 2",
@@ -2850,7 +3436,10 @@
         "condition": {},
         "item_object": "sm70_100",
         "parent_object": "sm70_100",
-        "folder_path": "RopewayContents/World/Location_Laboratory/LocationLevel_Laboratory/Item/common/ES_Common/02_Laboratory"
+        "folder_path": "RopewayContents/World/Location_Laboratory/LocationLevel_Laboratory/Item/common/ES_Common/02_Laboratory",
+        "allow_item": [
+            "Culture Sample"
+        ]
     },
     {
         "name": "On Box 1",
@@ -2859,7 +3448,10 @@
         "condition": {},
         "item_object": "sm70_101",
         "parent_object": "sm70_101",
-        "folder_path": "RopewayContents/World/Location_Laboratory/LocationLevel_Laboratory/Item/common/ES_Common/02_Laboratory"
+        "folder_path": "RopewayContents/World/Location_Laboratory/LocationLevel_Laboratory/Item/common/ES_Common/02_Laboratory",
+        "allow_item": [
+            "Culture Sample"
+        ]
     },
     {
         "name": "On Box 2",
@@ -2868,7 +3460,10 @@
         "condition": {},
         "item_object": "sm70_001",
         "parent_object": "sm70_001",
-        "folder_path": "RopewayContents/World/Location_Laboratory/LocationLevel_Laboratory/Item/common/ES_Common/02_Laboratory"
+        "folder_path": "RopewayContents/World/Location_Laboratory/LocationLevel_Laboratory/Item/common/ES_Common/02_Laboratory",
+        "allow_item": [
+            "Culture Sample"
+        ]
     },
     {
         "name": "On Cart",
@@ -2877,7 +3472,10 @@
         "condition": {},
         "item_object": "sm70_207",
         "parent_object": "sm70_207",
-        "folder_path": "RopewayContents/World/Location_Laboratory/LocationLevel_Laboratory/Item/common/ES_Common/02_Laboratory"
+        "folder_path": "RopewayContents/World/Location_Laboratory/LocationLevel_Laboratory/Item/common/ES_Common/02_Laboratory",
+        "allow_item": [
+            "Culture Sample"
+        ]
     },
     {
         "name": "On Floor",
@@ -2886,34 +3484,46 @@
         "condition": {},
         "item_object": "sm70_002",
         "parent_object": "sm70_002",
-        "folder_path": "RopewayContents/World/Location_Laboratory/LocationLevel_Laboratory/Item/common/ES_Common/02_Laboratory"
+        "folder_path": "RopewayContents/World/Location_Laboratory/LocationLevel_Laboratory/Item/common/ES_Common/02_Laboratory",
+        "allow_item": [
+            "Culture Sample"
+        ]
     },
     {
-        "name": "Cart near Corpse",
+        "name": "Cart Near Corpse",
         "region": "Server Room 2F",
         "original_item": "Gunpowder",
         "condition": {},
         "item_object": "sm70_205",
         "parent_object": "sm70_205",
-        "folder_path": "RopewayContents/World/Location_Laboratory/LocationLevel_Laboratory/Item/common/ES_Common/02_Laboratory"
+        "folder_path": "RopewayContents/World/Location_Laboratory/LocationLevel_Laboratory/Item/common/ES_Common/02_Laboratory",
+        "allow_item": [
+            "Culture Sample"
+        ]
     },
     {
-        "name": "Case near Servers",
+        "name": "Case Near Servers",
         "region": "Server Room 2F",
         "original_item": "Gunpowder",
         "condition": {},
         "item_object": "sm70_107",
         "parent_object": "sm70_107_Acase",
-        "folder_path": "RopewayContents/World/Location_Laboratory/LocationLevel_Laboratory/Item/common/ES_Common/02_Laboratory"
+        "folder_path": "RopewayContents/World/Location_Laboratory/LocationLevel_Laboratory/Item/common/ES_Common/02_Laboratory",
+        "allow_item": [
+            "Culture Sample"
+        ]
     },
     {
-        "name": "Case by Zombie",
+        "name": "Case By Zombie",
         "region": "Server Room",
         "original_item": "First Aid Spray",
         "condition": {},
         "item_object": "sm70_000",
         "parent_object": "sm70_000_Acase",
-        "folder_path": "RopewayContents/World/Location_Laboratory/LocationLevel_Laboratory/Item/common/ES_Common/02_Laboratory"
+        "folder_path": "RopewayContents/World/Location_Laboratory/LocationLevel_Laboratory/Item/common/ES_Common/02_Laboratory",
+        "allow_item": [
+            "Culture Sample"
+        ]
     },
     {
         "name": "Attache Case",
@@ -2922,7 +3532,10 @@
         "condition": {},
         "item_object": "sm70_208",
         "parent_object": "sm70_208_Acase",
-        "folder_path": "RopewayContents/World/Location_Laboratory/LocationLevel_Laboratory/Item/common/ES_Common/02_Laboratory"
+        "folder_path": "RopewayContents/World/Location_Laboratory/LocationLevel_Laboratory/Item/common/ES_Common/02_Laboratory",
+        "allow_item": [
+            "Culture Sample"
+        ]
     },
     {
         "name": "Attache Case",
@@ -2931,7 +3544,10 @@
         "condition": {},
         "item_object": "sm70_208",
         "parent_object": "sm70_208_Acase",
-        "folder_path": "RopewayContents/World/Location_Laboratory/LocationLevel_Laboratory/Item/common/ES_Common/02_Laboratory"
+        "folder_path": "RopewayContents/World/Location_Laboratory/LocationLevel_Laboratory/Item/common/ES_Common/02_Laboratory",
+        "allow_item": [
+            "Culture Sample"
+        ]
     },
     {
         "name": "Attache Case",
@@ -2940,7 +3556,10 @@
         "condition": {},
         "item_object": "sm70_207",
         "parent_object": "sm70_207_Acase",
-        "folder_path": "RopewayContents/World/Location_Laboratory/LocationLevel_Laboratory/Item/common/ES_Common/02_Laboratory"
+        "folder_path": "RopewayContents/World/Location_Laboratory/LocationLevel_Laboratory/Item/common/ES_Common/02_Laboratory",
+        "allow_item": [
+            "Culture Sample"
+        ]
     },
     {
         "name": "Cold Storage",
@@ -2959,7 +3578,10 @@
         "condition": {},
         "item_object": "sm70_205",
         "parent_object": "sm70_205",
-        "folder_path": "RopewayContents/World/Location_Laboratory/LocationLevel_Laboratory/Item/common/ES_Common/02_Laboratory"
+        "folder_path": "RopewayContents/World/Location_Laboratory/LocationLevel_Laboratory/Item/common/ES_Common/02_Laboratory",
+        "allow_item": [
+            "Culture Sample"
+        ]
     },
     {
         "name": "Synthesizer",
@@ -3011,6 +3633,15 @@
         "item_object": "sm70_000",
         "parent_object": "sm70_000",
         "folder_path": "RopewayContents/World/Location_Laboratory/LocationLevel_Laboratory/Item/common/ES_Common/03_Room01"
+    },
+    {
+        "name": "Breakable Box",
+        "region": "Worker's Break Room",
+        "original_item": "Explosive A",
+        "condition": {},
+        "item_object": "sm70_207",
+        "parent_object": "ItemPositions",
+        "folder_path": "RopewayContents/World/Location_Laboratory/Environments/st05_0202_0/gimmick"
     },
     {
         "name": "Attache Case",
@@ -3119,7 +3750,7 @@
         "item_object": "sm70_100",
         "parent_object": "sm70_100",
         "folder_path": "RopewayContents/World/Location_Laboratory/LocationLevel_Laboratory/Item/common/ES_Common/04_Room02"
-    },  
+    },
     {
         "name": "Final Fight 6",
         "region": "Weapons Testing Area",

--- a/residentevil3remake/data/jill/a/locations_inferno.json
+++ b/residentevil3remake/data/jill/a/locations_inferno.json
@@ -6,7 +6,20 @@
         "condition": {},
         "item_object": "sm74_200",
         "parent_object": "sm74_200_SideBag",
-        "folder_path": "RopewayContents/World/Location_DownTown/LocationLevel_DownTown/LocationFsm_DownTown/S03_1000/ES_S03_1000/Item/ES_S03_1000/I_100_Subway_Area/_Nightmare"
+        "folder_path": "RopewayContents/World/Location_DownTown/LocationLevel_DownTown/LocationFsm_DownTown/S03_1000/ES_S03_1000/Item/ES_S03_1000/I_100_Subway_Area/_Nightmare",
+        "allow_item": [
+            "Fire Hose",
+            "Lock Pick",
+            "Battery Pack",
+            "Kendo Gate Key",
+            "Locker Room Key",
+            "Tape Player",
+            "Fuse 1",
+            "Fuse 2",
+            "Fuse 3",
+            "Override Key",
+            "Culture Sample"
+        ]
     },
     {
         "name": "By Ticket Gate 4",
@@ -15,7 +28,20 @@
         "condition": {},
         "item_object": "WP3000",
         "parent_object": "WP3000",
-        "folder_path": "RopewayContents/World/Location_DownTown/LocationLevel_DownTown/LocationFsm_DownTown/S03_1000/ES_S03_1000/Item/ES_S03_1000/Weapon/Nightmare"
+        "folder_path": "RopewayContents/World/Location_DownTown/LocationLevel_DownTown/LocationFsm_DownTown/S03_1000/ES_S03_1000/Item/ES_S03_1000/Weapon/Nightmare",
+        "allow_item": [
+            "Fire Hose",
+            "Lock Pick",
+            "Battery Pack",
+            "Kendo Gate Key",
+            "Locker Room Key",
+            "Tape Player",
+            "Fuse 1",
+            "Fuse 2",
+            "Fuse 3",
+            "Override Key",
+            "Culture Sample"
+        ]
     },
     {
         "name": "On Barrel in Alley",
@@ -96,7 +122,18 @@
         "condition": {},
         "item_object": "sm73_313",
         "parent_object": "sm73_313",
-        "folder_path": "RopewayContents/World/Location_DownTown/LocationLevel_DownTown/LocationFsm_DownTown/S03_1000/ES_S03_1000/Item/ES_S03_1000/KeyItem/Nightmare"
+        "folder_path": "RopewayContents/World/Location_DownTown/LocationLevel_DownTown/LocationFsm_DownTown/S03_1000/ES_S03_1000/Item/ES_S03_1000/KeyItem/Nightmare",
+        "allow_item": [
+            "Battery Pack",
+            "Kendo Gate Key",
+            "Locker Room Key",
+            "Tape Player",
+            "Fuse 1",
+            "Fuse 2",
+            "Fuse 3",
+            "Override Key",
+            "Culture Sample"
+        ]
     },
     {
         "name": "Table 3",
@@ -105,7 +142,17 @@
         "condition": {},
         "item_object": "sm70_206",
         "parent_object": "sm70_206",
-        "folder_path": "RopewayContents/World/Location_DownTown/LocationLevel_DownTown/LocationFsm_DownTown/S03_1000/ES_S03_1000/Item/ES_S03_1000/I_900_Sewer/Nightmare"
+        "folder_path": "RopewayContents/World/Location_DownTown/LocationLevel_DownTown/LocationFsm_DownTown/S03_1000/ES_S03_1000/Item/ES_S03_1000/I_900_Sewer/Nightmare",
+        "allow_item": [
+            "Kendo Gate Key",
+            "Locker Room Key",
+            "Tape Player",
+            "Fuse 1",
+            "Fuse 2",
+            "Fuse 3",
+            "Override Key",
+            "Culture Sample"
+        ]
     },
     {
         "name": "On Display Case",
@@ -114,7 +161,17 @@
         "condition": {},
         "item_object": "sm70_205",
         "parent_object": "sm70_205",
-        "folder_path": "RopewayContents/World/Location_DownTown/LocationLevel_DownTown/LocationFsm_DownTown/S03_1000/ES_S03_1000/Item/ES_S03_1000/I_1100_Kendo_Area/Inferno"
+        "folder_path": "RopewayContents/World/Location_DownTown/LocationLevel_DownTown/LocationFsm_DownTown/S03_1000/ES_S03_1000/Item/ES_S03_1000/I_1100_Kendo_Area/Inferno",
+        "allow_item": [
+            "Kendo Gate Key",
+            "Locker Room Key",
+            "Tape Player",
+            "Fuse 1",
+            "Fuse 2",
+            "Fuse 3",
+            "Override Key",
+            "Culture Sample"
+        ]
     },
     {
         "name": "Near Door On Box",
@@ -136,7 +193,16 @@
         },
         "item_object": "sm71_200",
         "parent_object": "ItemPositions_sm41_410",
-        "folder_path": "RopewayContents/World/Location_RPD/Environments/st02_0202_0/gimmick_Escape"
+        "folder_path": "RopewayContents/World/Location_RPD/Environments/st02_0202_0/gimmick_Escape",
+        "allow_item": [
+            "Locker Room Key",
+            "Tape Player",
+            "Fuse 1",
+            "Fuse 2",
+            "Fuse 3",
+            "Override Key",
+            "Culture Sample"
+        ]
     },
     
     {
@@ -150,7 +216,16 @@
         },
         "item_object": "sm70_102",
         "parent_object": "ItemPositions_sm41_410",
-        "folder_path": "RopewayContents/World/Location_RPD/Environments/st02_0202_0/gimmick_Escape"
+        "folder_path": "RopewayContents/World/Location_RPD/Environments/st02_0202_0/gimmick_Escape",
+        "allow_item": [
+            "Locker Room Key",
+            "Tape Player",
+            "Fuse 1",
+            "Fuse 2",
+            "Fuse 3",
+            "Override Key",
+            "Culture Sample"
+        ]
     },
     {
         "name": "Table",
@@ -159,7 +234,16 @@
         "condition": {},
         "item_object": "sm70_001",
         "parent_object": "sm70_001_onlyUnlimited",
-        "folder_path": "RopewayContents/World/Location_RPD/LocationLevel_RPD/Item/common/ES_common"
+        "folder_path": "RopewayContents/World/Location_RPD/LocationLevel_RPD/Item/common/ES_common",
+        "allow_item": [
+            "Locker Room Key",
+            "Tape Player",
+            "Fuse 1",
+            "Fuse 2",
+            "Fuse 3",
+            "Override Key",
+            "Culture Sample"
+        ]
     },
     {
         "name": "Desk 1",
@@ -168,7 +252,16 @@
         "condition": {},
         "item_object": "sm70_102",
         "parent_object": "sm70_102_onlyUnlimited",
-        "folder_path": "RopewayContents/World/Location_RPD/LocationLevel_RPD/Item/common/ES_common"
+        "folder_path": "RopewayContents/World/Location_RPD/LocationLevel_RPD/Item/common/ES_common",
+        "allow_item": [
+            "Locker Room Key",
+            "Tape Player",
+            "Fuse 1",
+            "Fuse 2",
+            "Fuse 3",
+            "Override Key",
+            "Culture Sample"
+        ]
     },
     {
         "name": "Desk 2",
@@ -177,7 +270,16 @@
         "condition": {},
         "item_object": "sm70_100",
         "parent_object": "sm70_100_onlyUnlimited",
-        "folder_path": "RopewayContents/World/Location_RPD/LocationLevel_RPD/Item/common/ES_common"
+        "folder_path": "RopewayContents/World/Location_RPD/LocationLevel_RPD/Item/common/ES_common",
+        "allow_item": [
+            "Locker Room Key",
+            "Tape Player",
+            "Fuse 1",
+            "Fuse 2",
+            "Fuse 3",
+            "Override Key",
+            "Culture Sample"
+        ]
     },
     {
         "name": "Attache Case",
@@ -191,7 +293,14 @@
         },
         "item_object": "sm70_103",
         "parent_object": "Attache_MagnumBullet",
-        "folder_path": "RopewayContents/World/Location_Hospital/LocationLevel_Hospital/Item/common/LockerItem"
+        "folder_path": "RopewayContents/World/Location_Hospital/LocationLevel_Hospital/Item/common/LockerItem",
+        "allow_item": [
+            "Fuse 1",
+            "Fuse 2",
+            "Fuse 3",
+            "Override Key",
+            "Culture Sample"
+        ]
     },
     {
         "name": "By Truck",
@@ -200,7 +309,14 @@
         "condition": {},
         "item_object": "sm70_205",
         "parent_object": "st04_0302_sm70_205_01",
-        "folder_path": "RopewayContents/World/Location_Hospital2/LocationLevel_Hospital2/Item/common/ES_common/st04_0302"
+        "folder_path": "RopewayContents/World/Location_Hospital2/LocationLevel_Hospital2/Item/common/ES_common/st04_0302",
+        "allow_item": [
+            "Fuse 1",
+            "Fuse 2",
+            "Fuse 3",
+            "Override Key",
+            "Culture Sample"
+        ]
     },
     {
         "name": "Table",
@@ -209,7 +325,11 @@
         "condition": {},
         "item_object": "sm70_100",
         "parent_object": "sm70_100_onlyUnlimited",
-        "folder_path": "RopewayContents/World/Location_Laboratory/LocationLevel_Laboratory/Item/common/ES_Common/01_LockerRoom"
+        "folder_path": "RopewayContents/World/Location_Laboratory/LocationLevel_Laboratory/Item/common/ES_Common/01_LockerRoom",
+        "allow_item": [
+            "Override Key",
+            "Culture Sample"
+        ]
     },
     {
         "name": "By Corpse",
@@ -218,16 +338,24 @@
         "condition": {},
         "item_object": "sm70_205",
         "parent_object": "sm70_205_onlyUnlimited",
-        "folder_path": "RopewayContents/World/Location_Laboratory/LocationLevel_Laboratory/Item/common/ES_Common/02_Laboratory"
+        "folder_path": "RopewayContents/World/Location_Laboratory/LocationLevel_Laboratory/Item/common/ES_Common/02_Laboratory",
+        "allow_item": [
+            "Override Key",
+            "Culture Sample"
+        ]
     },
     {
-        "name": "Case near Servers",
+        "name": "Case Near Servers",
         "region": "Server Room 2F",
         "original_item": "Explosive B",
         "condition": {},
         "item_object": "sm70_208",
         "parent_object": "sm70_208_onlyUnlimited",
-        "folder_path": "RopewayContents/World/Location_Laboratory/LocationLevel_Laboratory/Item/common/ES_Common/02_Laboratory"
+        "folder_path": "RopewayContents/World/Location_Laboratory/LocationLevel_Laboratory/Item/common/ES_Common/02_Laboratory",
+        "allow_item": [
+            "Override Key",
+            "Culture Sample"
+        ]
     },
     {
         "name": "Attache Case",
@@ -236,7 +364,11 @@
         "condition": {},
         "item_object": "sm70_207",
         "parent_object": "sm70_208_Acase",
-        "folder_path": "RopewayContents/World/Location_Laboratory/LocationLevel_Laboratory/Item/common/ES_Common/02_Laboratory"
+        "folder_path": "RopewayContents/World/Location_Laboratory/LocationLevel_Laboratory/Item/common/ES_Common/02_Laboratory",
+        "allow_item": [
+            "Override Key",
+            "Culture Sample"
+        ]
     },
     {
         "name": "On Cart",
@@ -245,7 +377,11 @@
         "condition": {},
         "item_object": "sm70_002",
         "parent_object": "sm70_002_onlyUnlimited",
-        "folder_path": "RopewayContents/World/Location_Laboratory/LocationLevel_Laboratory/Item/common/ES_Common/02_Laboratory"
+        "folder_path": "RopewayContents/World/Location_Laboratory/LocationLevel_Laboratory/Item/common/ES_Common/02_Laboratory",
+        "allow_item": [
+            "Override Key",
+            "Culture Sample"
+        ]
     },
     {
         "name": "By Case",
@@ -254,7 +390,11 @@
         "condition": {},
         "item_object": "sm70_206",
         "parent_object": "sm70_206_onlyUnlimited",
-        "folder_path": "RopewayContents/World/Location_Laboratory/LocationLevel_Laboratory/Item/common/ES_Common/02_Laboratory"
+        "folder_path": "RopewayContents/World/Location_Laboratory/LocationLevel_Laboratory/Item/common/ES_Common/02_Laboratory",
+        "allow_item": [
+            "Override Key",
+            "Culture Sample"
+        ]
     },
     {
         "name": "Final Fight 10",
@@ -267,7 +407,7 @@
     },
     
     {
-        "name": "Counter by Door",
+        "name": "Counter By Door",
         "region": "Supermarket",
         "remove": true
     },
@@ -317,7 +457,7 @@
         "remove": true
     },
     {
-        "name": "Cabinet near Reception Window",
+        "name": "Cabinet Near Reception Window",
         "region": "West Office",
         "remove": true
     },
@@ -407,22 +547,22 @@
         "remove": true
     },
     {
-        "name": "In Container by Fuse 1",
+        "name": "In Container By Fuse 1",
         "region": "Warehouse",
         "remove": true
     },
     {
-        "name": "In Container by Fuse 2",
+        "name": "In Container By Fuse 2",
         "region": "Warehouse",
         "remove": true
     },
     {
-        "name": "In Container by Fuse 3",
+        "name": "In Container By Fuse 3",
         "region": "Warehouse",
         "remove": true
     },
     {
-        "name": "In Container by Fuse 4",
+        "name": "In Container By Fuse 4",
         "region": "Warehouse",
         "remove": true
     },

--- a/residentevil3remake/data/jill/a/locations_inferno.json
+++ b/residentevil3remake/data/jill/a/locations_inferno.json
@@ -117,23 +117,40 @@
         "folder_path": "RopewayContents/World/Location_DownTown/LocationLevel_DownTown/LocationFsm_DownTown/S03_1000/ES_S03_1000/Item/ES_S03_1000/I_1100_Kendo_Area/Inferno"
     },
     {
-        "name": "Inside Security Office",
-        "region": "East Courtyard",
+        "name": "Near Door On Box",
+        "region": "Guard Room",
         "original_item": "ID Card",
         "condition": {},
         "item_object": "sm73_203",
         "parent_object": "sm73_203",
-        "folder_path": "RopewayContents/World/Location_RPD/LocationLevel_RPD/Item/common/ES_common/NIGHTMARE",
-        "randomized": 0
-    },   
+        "folder_path": "RopewayContents/World/Location_RPD/LocationLevel_RPD/Item/common/ES_common/NIGHTMARE"
+    },
     {
-        "name": "Desk near Safe",
+        "name": "ID Case",
+        "region": "RPD Reception",
+        "original_item": "Scope - Assault Rifle",
+        "condition": {
+            "items": [
+                "ID Card"
+            ]
+        },
+        "item_object": "sm71_200",
+        "parent_object": "ItemPositions_sm41_410",
+        "folder_path": "RopewayContents/World/Location_RPD/Environments/st02_0202_0/gimmick_Escape"
+    },
+    
+    {
+        "name": "ID Case",
         "region": "West Office",
-        "original_item": "Handgun Ammo",
-        "condition": {},
-        "item_object": "sm70_100",
-        "parent_object": "sm70_100",
-        "folder_path": "RopewayContents/World/Location_RPD/LocationLevel_RPD/Item/common/ES_common"
+        "original_item": "Assault Rifle Ammo",
+        "condition": {
+            "items": [
+                "ID Card"
+            ]
+        },
+        "item_object": "sm70_102",
+        "parent_object": "ItemPositions_sm41_410",
+        "folder_path": "RopewayContents/World/Location_RPD/Environments/st02_0202_0/gimmick_Escape"
     },
     {
         "name": "Table",
@@ -290,12 +307,22 @@
         "remove": true
     },
     {
+        "name": "Near Breakable Box",
+        "region": "East Courtyard",
+        "remove": true
+    },
+    {
         "name": "Waiting Room Barricade",
         "region": "Main Lobby",
         "remove": true
     },
     {
         "name": "Cabinet near Reception Window",
+        "region": "West Office",
+        "remove": true
+    },
+    {
+        "name": "Desk Near Safe",
         "region": "West Office",
         "remove": true
     },

--- a/residentevil3remake/data/jill/a/locations_nightmare.json
+++ b/residentevil3remake/data/jill/a/locations_nightmare.json
@@ -6,7 +6,20 @@
         "condition": {},
         "item_object": "sm74_200",
         "parent_object": "sm74_200_SideBag",
-        "folder_path": "RopewayContents/World/Location_DownTown/LocationLevel_DownTown/LocationFsm_DownTown/S03_1000/ES_S03_1000/Item/ES_S03_1000/I_100_Subway_Area/_Nightmare"
+        "folder_path": "RopewayContents/World/Location_DownTown/LocationLevel_DownTown/LocationFsm_DownTown/S03_1000/ES_S03_1000/Item/ES_S03_1000/I_100_Subway_Area/_Nightmare",
+        "allow_item": [
+            "Fire Hose",
+            "Lock Pick",
+            "Battery Pack",
+            "Kendo Gate Key",
+            "Locker Room Key",
+            "Tape Player",
+            "Fuse 1",
+            "Fuse 2",
+            "Fuse 3",
+            "Override Key",
+            "Culture Sample"
+        ]
     },
     {
         "name": "By Ticket Gate 4",
@@ -15,7 +28,20 @@
         "condition": {},
         "item_object": "WP3000",
         "parent_object": "WP3000",
-        "folder_path": "RopewayContents/World/Location_DownTown/LocationLevel_DownTown/LocationFsm_DownTown/S03_1000/ES_S03_1000/Item/ES_S03_1000/Weapon/Nightmare"
+        "folder_path": "RopewayContents/World/Location_DownTown/LocationLevel_DownTown/LocationFsm_DownTown/S03_1000/ES_S03_1000/Item/ES_S03_1000/Weapon/Nightmare",
+        "allow_item": [
+            "Fire Hose",
+            "Lock Pick",
+            "Battery Pack",
+            "Kendo Gate Key",
+            "Locker Room Key",
+            "Tape Player",
+            "Fuse 1",
+            "Fuse 2",
+            "Fuse 3",
+            "Override Key",
+            "Culture Sample"
+        ]
     },
     {
         "name": "On Barrel in Alley",
@@ -45,7 +71,7 @@
         "folder_path": "RopewayContents/World/Location_DownTown/LocationLevel_DownTown/LocationFsm_DownTown/S03_1000/ES_S03_1000/Item/ES_S03_1000/I_200_T-Junction_Area/Nightmare"
     },
     {
-        "name": "Box by Donut Shop",
+        "name": "Box By Donut Shop",
         "region": "Shopping Plaza",
         "original_item": "High-Grade Gunpowder",
         "condition": {},
@@ -63,7 +89,7 @@
         "folder_path": "RopewayContents/World/Location_DownTown/LocationLevel_DownTown/LocationFsm_DownTown/S03_1000/ES_S03_1000/Item/ES_S03_1000/KeyItem/Nightmare"
     },
     {
-        "name": "Downed Zombie by Entrance",
+        "name": "Downed Zombie By Entrance",
         "region": "Subway Office",
         "original_item": "Hand Grenade",
         "condition": {},
@@ -90,13 +116,24 @@
         "folder_path": "RopewayContents/World/Location_DownTown/LocationLevel_DownTown/LocationFsm_DownTown/S03_1000/ES_S03_1000/Item/ES_S03_1000/KeyItem/Nightmare"
     },
     {
-        "name": "Power Panel by Scaffolding",
+        "name": "Power Panel By Scaffolding",
         "region": "Power Maze",
         "original_item": "Fancy Box - Red Jewel",
         "condition": {},
         "item_object": "sm73_313",
         "parent_object": "sm73_313",
-        "folder_path": "RopewayContents/World/Location_DownTown/LocationLevel_DownTown/LocationFsm_DownTown/S03_1000/ES_S03_1000/Item/ES_S03_1000/KeyItem/Nightmare"
+        "folder_path": "RopewayContents/World/Location_DownTown/LocationLevel_DownTown/LocationFsm_DownTown/S03_1000/ES_S03_1000/Item/ES_S03_1000/KeyItem/Nightmare",
+        "allow_item": [
+            "Battery Pack",
+            "Kendo Gate Key",
+            "Locker Room Key",
+            "Tape Player",
+            "Fuse 1",
+            "Fuse 2",
+            "Fuse 3",
+            "Override Key",
+            "Culture Sample"
+        ]
     },
     {
         "name": "Table 3",
@@ -105,7 +142,17 @@
         "condition": {},
         "item_object": "sm70_206",
         "parent_object": "sm70_206",
-        "folder_path": "RopewayContents/World/Location_DownTown/LocationLevel_DownTown/LocationFsm_DownTown/S03_1000/ES_S03_1000/Item/ES_S03_1000/I_900_Sewer/Nightmare"
+        "folder_path": "RopewayContents/World/Location_DownTown/LocationLevel_DownTown/LocationFsm_DownTown/S03_1000/ES_S03_1000/Item/ES_S03_1000/I_900_Sewer/Nightmare",
+        "allow_item": [
+            "Kendo Gate Key",
+            "Locker Room Key",
+            "Tape Player",
+            "Fuse 1",
+            "Fuse 2",
+            "Fuse 3",
+            "Override Key",
+            "Culture Sample"
+        ]
     },
     {
         "name": "Near Door On Box",
@@ -128,7 +175,14 @@
         },
         "item_object": "sm70_103",
         "parent_object": "Attache_MagnumBullet",
-        "folder_path": "RopewayContents/World/Location_Hospital/LocationLevel_Hospital/Item/common/LockerItem"
+        "folder_path": "RopewayContents/World/Location_Hospital/LocationLevel_Hospital/Item/common/LockerItem",
+        "allow_item": [
+            "Fuse 1",
+            "Fuse 2",
+            "Fuse 3",
+            "Override Key",
+            "Culture Sample"
+        ]
     },
     {
         "name": "Final Fight 10",
@@ -141,7 +195,7 @@
     },
 
     {
-        "name": "Counter by Door",
+        "name": "Counter By Door",
         "region": "Supermarket",
         "remove": true
     },

--- a/residentevil3remake/data/jill/a/locations_nightmare.json
+++ b/residentevil3remake/data/jill/a/locations_nightmare.json
@@ -108,14 +108,13 @@
         "folder_path": "RopewayContents/World/Location_DownTown/LocationLevel_DownTown/LocationFsm_DownTown/S03_1000/ES_S03_1000/Item/ES_S03_1000/I_900_Sewer/Nightmare"
     },
     {
-        "name": "Inside Security Office",
-        "region": "East Courtyard",
+        "name": "Near Door On Box",
+        "region": "Guard Room",
         "original_item": "ID Card",
         "condition": {},
         "item_object": "sm73_203",
         "parent_object": "sm73_203",
-        "folder_path": "RopewayContents/World/Location_RPD/LocationLevel_RPD/Item/common/ES_common/NIGHTMARE",
-        "randomized": 0
+        "folder_path": "RopewayContents/World/Location_RPD/LocationLevel_RPD/Item/common/ES_common/NIGHTMARE"
     },
     {
         "name": "Attache Case",

--- a/residentevil3remake/data/jill/items.json
+++ b/residentevil3remake/data/jill/items.json
@@ -416,7 +416,7 @@
     "type": "Ammo",
     "name": "Assault Rifle Ammo",
     "decimal": "33",
-    "count": 50,
+    "count": 40,
     "progression": 0
   },
   {

--- a/residentevil3remake/data/jill/items.json
+++ b/residentevil3remake/data/jill/items.json
@@ -402,21 +402,21 @@
     "type": "Ammo",
     "name": "Handgun Ammo",
     "decimal": "31",
-    "count": 15,
+    "count": 10,
     "progression": 0
   },
   {
     "type": "Ammo",
     "name": "Shotgun Shells",
     "decimal": "32",
-    "count": 6,
+    "count": 5,
     "progression": 0
   },
   {
     "type": "Ammo",
     "name": "Assault Rifle Ammo",
     "decimal": "33",
-    "count": 100,
+    "count": 50,
     "progression": 0
   },
   {

--- a/residentevil3remake/data/jill/items.json
+++ b/residentevil3remake/data/jill/items.json
@@ -16,7 +16,7 @@
   {
     "type": "Key",
     "name": "Lock Pick",
-    "decimal": "185",
+    "decimal": "151",
     "count": 1,
     "progression": 1
   },

--- a/residentevil3remake/data/jill/items.json
+++ b/residentevil3remake/data/jill/items.json
@@ -281,7 +281,7 @@
   },
   {
     "type": "Weapon",
-    "name": "M3",
+    "name": "M3 Shotgun",
     "decimal": "11",
     "count": 4,
     "progression": 0,

--- a/residentevil3remake/data/jill/items.json
+++ b/residentevil3remake/data/jill/items.json
@@ -281,22 +281,6 @@
   },
   {
     "type": "Weapon",
-    "name": "Samurai Edge",
-    "decimal": "4",
-    "count": 10,
-    "progression": 0,
-    "ammo": "Handgun Ammo"
-  },
-  {
-    "type": "Weapon",
-    "name": "Infinite MUP",
-    "decimal": "7",
-    "count": 10,
-    "progression": 0,
-    "ammo": "Handgun Ammo"
-  },
-  {
-    "type": "Weapon",
     "name": "M3",
     "decimal": "11",
     "count": 4,
@@ -313,13 +297,6 @@
   },
   {
     "type": "Weapon",
-    "name": "Infinite Assault Rifle",
-    "decimal": "22",
-    "count": 32,
-    "progression": 0
-  },
-  {
-    "type": "Weapon",
     "name": "MAG",
     "decimal": "31",
     "count": 8,
@@ -328,32 +305,11 @@
   },
   {
     "type": "Weapon",
-    "name": "RAI-DEN",
-    "decimal": "32",
-    "count": 7,
-    "progression": 0
-  },
-  {
-    "type": "Weapon",
     "name": "MGL Grenade Launcher",
     "decimal": "42",
     "count": 6,
     "progression": 0,
     "ammo": "Explosive Rounds"
-  },
-  {
-    "type": "Weapon",
-    "name": "HOT DOGGER",
-    "decimal": "48",
-    "count": 1,
-    "progression": 0
-  },
-  {
-    "type": "Weapon",
-    "name": "Infinite Rocket Launcher",
-    "decimal": "49",
-    "count": 1,
-    "progression": 0
   },
 
   {
@@ -496,13 +452,6 @@
     "name": "Acid Rounds",
     "decimal": "39",
     "count": 3,
-    "progression": 0
-  },
-  {
-    "type": "Ammo",
-    "name": "Infinity Gauntlet",
-    "decimal": "",
-    "count": 1,
     "progression": 0
   },
 


### PR DESCRIPTION
**Been a bit since the last update, hopefully ya'll enjoy this one** 😄 

**Jill and Carlos no longer receive every item, and properly receive their own respective items.** This means you will no longer find the others key items, weaponry, ammo etc in their boxes anymore. 

**New randomized locations due to the above change:** 

- Nemesis Cases (Now have the potential to have progression if allow_missable_locations is turned on in the yaml but will otherwise have useful/junk/traps)

- Safes, they now are randomized the old way again, and do not automatically mark off the map as it was the simpler solution to randomizing the location again

- The Tactical Grip for the Assault Rifle, no reason to have it static anymore.

**Some cutscene items are now in the pool proper:**
- Lock Pick
- Override Key
- Culture Sample

**The Shotgun is also now properly in the pool and adds 3 locations** (there were 3 spots where the shotgun could be if you missed it)

**Last but not least, all Breakable Boxes are now in the pool so I hope you remember where they all are.**

This is a pretty massive update that unfortunately breaks compatibility with the poptracker pack, so be sure to use Universal Tracker or the !missing command to follow along with your progress to make sure you haven't missed any item locations.

Happy Gaming!